### PR TITLE
fix: added norwegian translation for "no signal"

### DIFF
--- a/locale/no.yml
+++ b/locale/no.yml
@@ -171,3 +171,4 @@ no:
   Banner & Sound: Banner & Lyd
   Banner only: Bare banner
   Sound only: Bare lyd
+  no signal: ingen signal


### PR DESCRIPTION
saw that there was a new entry "no signal" that needed translation in the french PR (https://github.com/meshtastic/device-ui/pull/22).

now added norwegian translation