### PR TITLE
style: Update en.yml and Greek translation, fix SD card status display

### DIFF
--- a/locale/el.yml
+++ b/locale/el.yml
@@ -1,12 +1,12 @@
 el:
   no new messages: κανένα νέο μήνυμα
   1 of 1 nodes online: 1 Κόμβος online
-  'uptime 00:00:00': Χρόν.λειτ. 00:00:00
+  uptime 00:00:00: Χρόν.λειτ. 00:00:00
   LoRa 0.0 MHz: ~
   no signal: Χωρίς Σήμα
   silent: Σίγαση
   no SD card detected: Δεν βρέθηκε κάρτα SD
-  'Heap: 0\nLVGL: 0': ~
+  "Heap: 0\nLVGL: 0": ~
   DEL: ~
   Settings: Ρυθμίσεις
   'User name: ': 'Όνομα χρήστη: '
@@ -23,6 +23,7 @@ el:
   'Message Alert Buzzer: on': 'Buzzer Ειδοποίησης: ενεργό'
   'Language: English': 'Γλώσσα: Ελληνικά'
   Configuration Reset: Επαναφορά ρυθμίσεων
+  Backup & Restore: Αντίγρ. Ασφαλείας
   Reboot / Shutdown: Επανεκκίνηση / Τερματισμός
   Tools: Εργαλεία
   Mesh Detector: Ανιχνευτής Δικτύων
@@ -47,12 +48,12 @@ el:
   Primary Channel: Κύριο Κανάλι
   <unset>: <αόριστο>
   Secondary Channels: Δευτερεύοντα Κανάλια
-  LONG FAST\nLONG SLOW\n-- deprecated --\nMEDIUM SLOW\nMEDIUM FAST\nSHORT SLOW\nSHORT FAST\nLONG MODERATE\nSHORT TURBO: LONG FAST\nLONG SLOW\n-- Καταργήθηκε --\nMEDIUM SLOW\nMEDIUM FAST\nSHORT SLOW\nSHORT FAST\nLONG MODERATE\nSHORT TURBO
-  Client\nClient Mute\nRouter\nRepeater\nTracker\nSensor\nTAK\nClient Hidden\nLost & Found\nTAK Tracker: ~
+  "LONG FAST\nLONG SLOW\n-- deprecated --\nMEDIUM SLOW\nMEDIUM FAST\nSHORT SLOW\nSHORT FAST\nLONG MODERATE\nSHORT TURBO": "LONG FAST\nLONG SLOW\n-- Καταργήθηκε --\nMEDIUM SLOW\nMEDIUM FAST\nSHORT SLOW\nSHORT FAST\nLONG MODERATE\nSHORT TURBO"
+  "Client\nClient Mute\nRouter\nRepeater\nTracker\nSensor\nTAK\nClient Hidden\nLost & Found\nTAK Tracker": ~
   WiFi SSID: ~
   WiFi pre-shared Key: ~
   'Brightness: 60%': 'Ένταση: 60%'
-  Dark\nLight: Σκούρο\nΑνοιχτό
+  "Dark\nLight": "Σκούρο\nΑνοιχτό"
   'Timeout: 60s': 'Λήξη: 60s'
   Screen Lock: Κλείδ. Οθόνης
   Settings Lock: Κλείδ. Ρυθμίσεων
@@ -65,7 +66,10 @@ el:
   Default: Προεπιλογή
   Zone: Ζώνη
   City: Πόλη
-  NodeDB Reset\nFactory Reset\nClear Chat History: Καθαρ. NodeDB\nΕπαν.Εργοσ. Ρυθμίσεων\nΚαθαρ.Ιστ. Συνομιλιών
+  Backup: Δημιουρ.Αντιγρ.
+  Restore: Επαναφ.Αντιγρ.
+  Public/Private Key: ~
+  "NodeDB Reset\nFactory Reset\nClear Chat History": "Καθαρ. NodeDB\nΕπαν.Εργοσ. Ρυθμίσεων\nΚαθαρ.Ιστ. Συνομιλιών"
   Channel Name: Όνομα Καναλιού
   Pre-shared Key: ~
   Filter: Φίλτρο
@@ -82,13 +86,13 @@ el:
   Telemetry: Τηλεμετρία
   IAQ: Ποιότητα Αέρα (ΠΑΕΧ)
   Start: Έναρξη
-  choose\nnode: επιλογή κόμβου
+  "choose\nnode": "επιλογή\nκόμβου"
   choose target node: επιλογή στόχου
-  New Message from\n: Νέο μήνυμα από\n
+  "New Message from\n": "Νέο μήνυμα από\n"
   Restoring messages ...: Επαναφορά μηνυμάτων...
-  Resynch ...: Συγχρονισμός ...
   Please set region and name: Ορίστε περιοχή και όνομα
   Region: Περιοχή
+  Resynch ...: Συγχρονισμός ...
   OK: ~
   Cancel: Άκυρο
   now: τώρα
@@ -98,7 +102,9 @@ el:
   'Screen Calibration: %s': 'Διαμέτρ. Οθόνης: %s'
   done: έγινε
   default: προεπιλογή
-  Client\nClient Mute\nTracker\nSensor\nTAK\nClient Hidden\nLost & Found\nTAK Tracker: ~
+  "Client\nClient Mute\nTracker\nSensor\nTAK\nClient Hidden\nLost & Found\nTAK Tracker": ~
+  Rebooting ...: Επανεκκίνηση ...
+  '>> Programming mode <<': '>> Λειτ. Προγρ/σμού <<'
   Enter Text ...: Εισάγετε Κείμενο ...
   '!Enter Filter ...': Εισάγετε Φίλτρο ...
   Enter Filter ...: Εισάγετε Φίλτρο ...
@@ -123,7 +129,6 @@ el:
   Util %0.1f%%  Air %0.1f%%: ~
   'hops: %d': 'Αναμεταδόσεις: %d'
   unknown: άγνωστο
-  Rebooting ...: Επανεκκίνηση ...
   Shutting down ...: Τερματισμός ...
   region unset: Περιοχή μη-ορισμ.
   Banner & Sound: Πλαίσιο & Ήχος
@@ -131,10 +136,14 @@ el:
   Sound only: Ήχος μόνο
   'Message Alert: %s': 'Ειδοποιήσεις: %s'
   'Channel: %s': 'Κύριο Κανάλι: %s'
+  Failed to write keys!: Αποτυχία εγγρ. κλειδιών!
+  Failed to restore keys!: Αποτυχία επαναφ. κλειδιών!
+  Failed to parse keys!: Αποτυχία χρήσης κλειδιών!
+  Failed to retrieve keys!: Αποτυχία λήψης κλειδιών!
   '%d active chat(s)':
     one: '%d ενεργ. συνομιλία'
     other: '%d ενεργ. συνομιλίες'
-  New message from \n%s: Νέο μήνυμα από \n%s
+  "New message from \n%s": "Νέο μήνυμα από \n%s"
   'Input Control: %s/%s': 'Έλεγχος Εισόδου: %s/%s'
   '%d of %d nodes online':
     one: 1 Κόμβος online
@@ -143,5 +152,5 @@ el:
   '%d new message': '%d νέο μήνυμα'
   '%d new messages': '%d νέα μηνύματα'
   'uptime: %02d:%02d:%02d': 'Χρόνος Λειτ.: %02d:%02d:%02d'
-  'Heap: %d (%d%%)\nLVGL: %d (%d%%)': ~
-  '%s (%0.1f GB)\nUsed: %d MB (%d%%)': '%s (%d)\nΧρήση: %d MB (%d%%)'
+  "%s (%0.1f GB)\nUsed: %d MB (%d%%)": "%s (%0.1f GB)\nΧρησ.: %d MB (%d%%)"
+  "Heap: %d (%d%%)\nLVGL: %d (%d%%)": ~

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -23,6 +23,7 @@ en:
   'Message Alert Buzzer: on': ~
   'Language: English': ~
   Configuration Reset: ~
+  Backup & Restore: ~
   Reboot / Shutdown: ~
   Tools: ~
   Mesh Detector: ~
@@ -65,6 +66,9 @@ en:
   Default: ~
   Zone: ~
   City: ~
+  Backup: ~
+  Restore: ~
+  Public/Private Key: ~
   "NodeDB Reset\nFactory Reset\nClear Chat History": ~
   Channel Name: ~
   Pre-shared Key: ~
@@ -86,9 +90,9 @@ en:
   choose target node: ~
   "New Message from\n": ~
   Restoring messages ...: ~
-  Resynch ...: ~
   Please set region and name: ~
   Region: ~
+  Resynch ...: ~
   OK: ~
   Cancel: ~
   now: ~
@@ -132,6 +136,10 @@ en:
   Sound only: ~
   'Message Alert: %s': ~
   'Channel: %s': ~
+  Failed to write keys!: ~
+  Failed to restore keys!: ~
+  Failed to parse keys!: ~
+  Failed to retrieve keys!: ~
   '%d active chat(s)':
     one: ~
     other: ~

--- a/locale/lv_i18n.c
+++ b/locale/lv_i18n.c
@@ -37,11 +37,6 @@ static inline uint32_t op_t(uint32_t val)
     UNUSED(val);
     return 0;
 }
-static inline uint32_t op_e(uint32_t val)
-{
-    UNUSED(val);
-    return 0;
-}
 
 static uint8_t en_plural_fn(int32_t num)
 {
@@ -61,7 +56,7 @@ static const lv_i18n_lang_t en_lang = {.locale_name = "en",
 
                                        .locale_plural_fn = en_plural_fn};
 
-static const lv_i18n_phrase_t de_singulars[] = {
+static lv_i18n_phrase_t de_singulars[] = {
     {"User name: %s", "Benutzer: %s"},
     {"Device Role: %s", "Gerätemodus: %s"},
     {"no new messages", "keine Nachrichten"},
@@ -183,11 +178,11 @@ static const lv_i18n_phrase_t de_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t de_plurals_one[] = {
+static lv_i18n_phrase_t de_plurals_one[] = {
     {"%d active chat(s)", "%d aktives Gespräch"}, {"%d of %d nodes online", "1 Gerät online"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t de_plurals_other[] = {
+static lv_i18n_phrase_t de_plurals_other[] = {
     {"%d active chat(s)", "%d aktive Gespräche"}, {"%d of %d nodes online", "%d / %d Geräte online"}, {NULL, NULL} // End mark
 };
 
@@ -211,7 +206,7 @@ static const lv_i18n_lang_t de_lang = {.locale_name = "de",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = de_plurals_other,
                                        .locale_plural_fn = de_plural_fn};
 
-static const lv_i18n_phrase_t el_singulars[] = {
+static lv_i18n_phrase_t el_singulars[] = {
     {"no new messages", "κανένα νέο μήνυμα"},
     {"1 of 1 nodes online", "1 Κόμβος online"},
     {"uptime 00:00:00", "Χρόν.λειτ. 00:00:00"},
@@ -233,6 +228,7 @@ static const lv_i18n_phrase_t el_singulars[] = {
     {"Message Alert Buzzer: on", "Buzzer Ειδοποίησης: ενεργό"},
     {"Language: English", "Γλώσσα: Ελληνικά"},
     {"Configuration Reset", "Επαναφορά ρυθμίσεων"},
+    {"Backup & Restore", "Αντίγρ. Ασφαλείας"},
     {"Reboot / Shutdown", "Επανεκκίνηση / Τερματισμός"},
     {"Tools", "Εργαλεία"},
     {"Mesh Detector", "Ανιχνευτής Δικτύων"},
@@ -255,12 +251,10 @@ static const lv_i18n_phrase_t el_singulars[] = {
     {"Primary Channel", "Κύριο Κανάλι"},
     {"<unset>", "<αόριστο>"},
     {"Secondary Channels", "Δευτερεύοντα Κανάλια"},
-    {"LONG FAST\\nLONG SLOW\\n-- deprecated --\\nMEDIUM SLOW\\nMEDIUM FAST\\nSHORT SLOW\\nSHORT FAST\\nLONG MODERATE\\nSHORT "
-     "TURBO",
-     "LONG FAST\\nLONG SLOW\\n-- Καταργήθηκε --\\nMEDIUM SLOW\\nMEDIUM FAST\\nSHORT SLOW\\nSHORT FAST\\nLONG MODERATE\\nSHORT "
-     "TURBO"},
+    {"LONG FAST\nLONG SLOW\n-- deprecated --\nMEDIUM SLOW\nMEDIUM FAST\nSHORT SLOW\nSHORT FAST\nLONG MODERATE\nSHORT TURBO",
+     "LONG FAST\nLONG SLOW\n-- Καταργήθηκε --\nMEDIUM SLOW\nMEDIUM FAST\nSHORT SLOW\nSHORT FAST\nLONG MODERATE\nSHORT TURBO"},
     {"Brightness: 60%", "Ένταση: 60%"},
-    {"Dark\\nLight", "Σκούρο\\nΑνοιχτό"},
+    {"Dark\nLight", "Σκούρο\nΑνοιχτό"},
     {"Timeout: 60s", "Λήξη: 60s"},
     {"Screen Lock", "Κλείδ. Οθόνης"},
     {"Settings Lock", "Κλείδ. Ρυθμίσεων"},
@@ -273,7 +267,9 @@ static const lv_i18n_phrase_t el_singulars[] = {
     {"Default", "Προεπιλογή"},
     {"Zone", "Ζώνη"},
     {"City", "Πόλη"},
-    {"NodeDB Reset\\nFactory Reset\\nClear Chat History", "Καθαρ. NodeDB\\nΕπαν.Εργοσ. Ρυθμίσεων\\nΚαθαρ.Ιστ. Συνομιλιών"},
+    {"Backup", "Δημιουρ.Αντιγρ."},
+    {"Restore", "Επαναφ.Αντιγρ."},
+    {"NodeDB Reset\nFactory Reset\nClear Chat History", "Καθαρ. NodeDB\nΕπαν.Εργοσ. Ρυθμίσεων\nΚαθαρ.Ιστ. Συνομιλιών"},
     {"Channel Name", "Όνομα Καναλιού"},
     {"Filter", "Φίλτρο"},
     {"Unknown", "Άγνωστες"},
@@ -287,19 +283,21 @@ static const lv_i18n_phrase_t el_singulars[] = {
     {"Telemetry", "Τηλεμετρία"},
     {"IAQ", "Ποιότητα Αέρα (ΠΑΕΧ)"},
     {"Start", "Έναρξη"},
-    {"choose\\nnode", "επιλογή κόμβου"},
+    {"choose\nnode", "επιλογή\nκόμβου"},
     {"choose target node", "επιλογή στόχου"},
-    {"New Message from\\n", "Νέο μήνυμα από\\n"},
+    {"New Message from\n", "Νέο μήνυμα από\n"},
     {"Restoring messages ...", "Επαναφορά μηνυμάτων..."},
-    {"Resynch ...", "Συγχρονισμός ..."},
     {"Please set region and name", "Ορίστε περιοχή και όνομα"},
     {"Region", "Περιοχή"},
+    {"Resynch ...", "Συγχρονισμός ..."},
     {"Cancel", "Άκυρο"},
     {"now", "τώρα"},
     {"Lock: %s/%s", "Κλείδωμα Συσκευής"},
     {"Screen Calibration: %s", "Διαμέτρ. Οθόνης: %s"},
     {"done", "έγινε"},
     {"default", "προεπιλογή"},
+    {"Rebooting ...", "Επανεκκίνηση ..."},
+    {">> Programming mode <<", ">> Λειτ. Προγρ/σμού <<"},
     {"Enter Text ...", "Εισάγετε Κείμενο ..."},
     {"!Enter Filter ...", "Εισάγετε Φίλτρο ..."},
     {"Enter Filter ...", "Εισάγετε Φίλτρο ..."},
@@ -322,7 +320,6 @@ static const lv_i18n_phrase_t el_singulars[] = {
     {"<not set>", "<χωρίς ρύθμιση>"},
     {"hops: %d", "Αναμεταδόσεις: %d"},
     {"unknown", "άγνωστο"},
-    {"Rebooting ...", "Επανεκκίνηση ..."},
     {"Shutting down ...", "Τερματισμός ..."},
     {"region unset", "Περιοχή μη-ορισμ."},
     {"Banner & Sound", "Πλαίσιο & Ήχος"},
@@ -330,21 +327,25 @@ static const lv_i18n_phrase_t el_singulars[] = {
     {"Sound only", "Ήχος μόνο"},
     {"Message Alert: %s", "Ειδοποιήσεις: %s"},
     {"Channel: %s", "Κύριο Κανάλι: %s"},
-    {"New message from \\n%s", "Νέο μήνυμα από \\n%s"},
+    {"Failed to write keys!", "Αποτυχία εγγρ. κλειδιών!"},
+    {"Failed to restore keys!", "Αποτυχία επαναφ. κλειδιών!"},
+    {"Failed to parse keys!", "Αποτυχία χρήσης κλειδιών!"},
+    {"Failed to retrieve keys!", "Αποτυχία λήψης κλειδιών!"},
+    {"New message from \n%s", "Νέο μήνυμα από \n%s"},
     {"Input Control: %s/%s", "Έλεγχος Εισόδου: %s/%s"},
     {"Filter: %d of %d nodes", "Φίλτρο: %d από %d κόμβοι"},
     {"%d new message", "%d νέο μήνυμα"},
     {"%d new messages", "%d νέα μηνύματα"},
     {"uptime: %02d:%02d:%02d", "Χρόνος Λειτ.: %02d:%02d:%02d"},
-    {"%s (%0.1f GB)\\nUsed: %d MB (%d%%)", "%s (%d)\\nΧρήση: %d MB (%d%%)"},
+    {"%s (%0.1f GB)\nUsed: %d MB (%d%%)", "%s (%0.1f GB)\nΧρησ.: %d MB (%d%%)"},
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t el_plurals_one[] = {
+static lv_i18n_phrase_t el_plurals_one[] = {
     {"%d active chat(s)", "%d ενεργ. συνομιλία"}, {"%d of %d nodes online", "1 Κόμβος online"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t el_plurals_other[] = {
+static lv_i18n_phrase_t el_plurals_other[] = {
     {"%d active chat(s)", "%d ενεργ. συνομιλίες"}, {"%d of %d nodes online", "%d / %d Κόμβοι online"}, {NULL, NULL} // End mark
 };
 
@@ -364,7 +365,7 @@ static const lv_i18n_lang_t el_lang = {.locale_name = "el",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = el_plurals_other,
                                        .locale_plural_fn = el_plural_fn};
 
-static const lv_i18n_phrase_t es_singulars[] = {
+static lv_i18n_phrase_t es_singulars[] = {
     {"no new messages", "Sin mensajes nuevos"},
     {"1 of 1 nodes online", "1 de 1 nodos activos"},
     {"DEL", "BOR"},
@@ -494,17 +495,9 @@ static uint8_t es_plural_fn(int32_t num)
 {
     uint32_t n = op_n(num);
     UNUSED(n);
-    uint32_t e = op_e(n);
-    UNUSED(e);
-    uint32_t i = op_i(n);
-    UNUSED(i);
-    uint32_t v = op_v(n);
-    UNUSED(v);
-    uint32_t i1000000 = i % 1000000;
+
     if ((n == 1))
         return LV_I18N_PLURAL_TYPE_ONE;
-    if ((e == 0 && i != 0 && i1000000 == 0 && v == 0) || ((!(0 <= e && e <= 5))))
-        return LV_I18N_PLURAL_TYPE_MANY;
     return LV_I18N_PLURAL_TYPE_OTHER;
 }
 
@@ -513,7 +506,7 @@ static const lv_i18n_lang_t es_lang = {.locale_name = "es",
 
                                        .locale_plural_fn = es_plural_fn};
 
-static const lv_i18n_phrase_t fi_singulars[] = {
+static lv_i18n_phrase_t fi_singulars[] = {
     {"no new messages", "ei uusia viestejä"},
     {"1 of 1 nodes online", "1/1 nodea verkossa"},
     {"uptime 00:00:00", "käyttöaika 00:00:00"},
@@ -643,7 +636,7 @@ static const lv_i18n_lang_t fi_lang = {.locale_name = "fi",
 
                                        .locale_plural_fn = fi_plural_fn};
 
-static const lv_i18n_phrase_t fr_singulars[] = {
+static lv_i18n_phrase_t fr_singulars[] = {
     {"no new messages", "0 nouveau message"},
     {"1 of 1 nodes online", "1 sur 1 noeud actif"},
     {"uptime 00:00:00", "Activité: 00:00:00"},
@@ -775,15 +768,9 @@ static uint8_t fr_plural_fn(int32_t num)
     UNUSED(n);
     uint32_t i = op_i(n);
     UNUSED(i);
-    uint32_t e = op_e(n);
-    UNUSED(e);
-    uint32_t v = op_v(n);
-    UNUSED(v);
-    uint32_t i1000000 = i % 1000000;
+
     if ((((i == 0) || (i == 1))))
         return LV_I18N_PLURAL_TYPE_ONE;
-    if ((e == 0 && i != 0 && i1000000 == 0 && v == 0) || ((!(0 <= e && e <= 5))))
-        return LV_I18N_PLURAL_TYPE_MANY;
     return LV_I18N_PLURAL_TYPE_OTHER;
 }
 
@@ -792,7 +779,7 @@ static const lv_i18n_lang_t fr_lang = {.locale_name = "fr",
 
                                        .locale_plural_fn = fr_plural_fn};
 
-static const lv_i18n_phrase_t it_singulars[] = {
+static lv_i18n_phrase_t it_singulars[] = {
     {"no new messages", "nessun messaggio"},
     {"1 of 1 nodes online", "1 di 1 nodi online"},
     {"uptime 00:00:00", "tempo di attività 00:00:00"},
@@ -926,11 +913,11 @@ static const lv_i18n_phrase_t it_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t it_plurals_one[] = {
+static lv_i18n_phrase_t it_plurals_one[] = {
     {"%d active chat(s)", "%d chat attiva"}, {"%d of %d nodes online", "1 nodo online"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t it_plurals_other[] = {
+static lv_i18n_phrase_t it_plurals_other[] = {
     {"%d active chat(s)", "%d chat attive"}, {"%d of %d nodes online", "%d di %d nodi online"}, {NULL, NULL} // End mark
 };
 
@@ -942,13 +929,9 @@ static uint8_t it_plural_fn(int32_t num)
     UNUSED(i);
     uint32_t v = op_v(n);
     UNUSED(v);
-    uint32_t e = op_e(n);
-    UNUSED(e);
-    uint32_t i1000000 = i % 1000000;
+
     if ((i == 1 && v == 0))
         return LV_I18N_PLURAL_TYPE_ONE;
-    if ((e == 0 && i != 0 && i1000000 == 0 && v == 0) || ((!(0 <= e && e <= 5))))
-        return LV_I18N_PLURAL_TYPE_MANY;
     return LV_I18N_PLURAL_TYPE_OTHER;
 }
 
@@ -958,7 +941,7 @@ static const lv_i18n_lang_t it_lang = {.locale_name = "it",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = it_plurals_other,
                                        .locale_plural_fn = it_plural_fn};
 
-static const lv_i18n_phrase_t nl_singulars[] = {
+static lv_i18n_phrase_t nl_singulars[] = {
     {"no new messages", "0 nieuwe berichten"},
     {"1 of 1 nodes online", "1 van 1 nodes online"},
     {"uptime 00:00:00", "uptime 00:00:00"},
@@ -1119,7 +1102,7 @@ static const lv_i18n_lang_t nl_lang = {.locale_name = "nl",
 
                                        .locale_plural_fn = nl_plural_fn};
 
-static const lv_i18n_phrase_t no_singulars[] = {
+static lv_i18n_phrase_t no_singulars[] = {
     {"no new messages", "Ingen nye meldinger"},
     {"1 of 1 nodes online", "1 av 1 noder online"},
     {"uptime 00:00:00", "oppetid 00:00:00"},
@@ -1251,11 +1234,11 @@ static const lv_i18n_phrase_t no_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t no_plurals_one[] = {
+static lv_i18n_phrase_t no_plurals_one[] = {
     {"%d active chat(s)", "1 aktiv chat"}, {"%d of %d nodes online", "1 node online"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t no_plurals_other[] = {
+static lv_i18n_phrase_t no_plurals_other[] = {
     {"%d active chat(s)", "%d aktive chat"}, {"%d of %d nodes online", "%d av %d noder online"}, {NULL, NULL} // End mark
 };
 
@@ -1275,7 +1258,7 @@ static const lv_i18n_lang_t no_lang = {.locale_name = "no",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = no_plurals_other,
                                        .locale_plural_fn = no_plural_fn};
 
-static const lv_i18n_phrase_t pl_singulars[] = {
+static lv_i18n_phrase_t pl_singulars[] = {
     {"no new messages", "Brak wiadomości"},
     {"1 of 1 nodes online", "1 z 1 węzłów online"},
     {"User name: ", "Nazwa"},
@@ -1404,7 +1387,7 @@ static const lv_i18n_lang_t pl_lang = {.locale_name = "pl",
 
                                        .locale_plural_fn = pl_plural_fn};
 
-static const lv_i18n_phrase_t pt_singulars[] = {
+static lv_i18n_phrase_t pt_singulars[] = {
     {"no new messages", "Nenhuma mensagem"},
     {"1 of 1 nodes online", "1 dispositivo online"},
     {"uptime 00:00:00", "Tempo ligado\n00:00:00"},
@@ -1529,11 +1512,11 @@ static const lv_i18n_phrase_t pt_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t pt_plurals_one[] = {
+static lv_i18n_phrase_t pt_plurals_one[] = {
     {"%d of %d nodes online", "1 dispositivo online"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t pt_plurals_other[] = {
+static lv_i18n_phrase_t pt_plurals_other[] = {
     {"%d of %d nodes online", "%d/%d dispositivos online"}, {NULL, NULL} // End mark
 };
 
@@ -1543,15 +1526,9 @@ static uint8_t pt_plural_fn(int32_t num)
     UNUSED(n);
     uint32_t i = op_i(n);
     UNUSED(i);
-    uint32_t e = op_e(n);
-    UNUSED(e);
-    uint32_t v = op_v(n);
-    UNUSED(v);
-    uint32_t i1000000 = i % 1000000;
+
     if (((0 <= i && i <= 1)))
         return LV_I18N_PLURAL_TYPE_ONE;
-    if ((e == 0 && i != 0 && i1000000 == 0 && v == 0) || ((!(0 <= e && e <= 5))))
-        return LV_I18N_PLURAL_TYPE_MANY;
     return LV_I18N_PLURAL_TYPE_OTHER;
 }
 
@@ -1581,7 +1558,7 @@ static const lv_i18n_lang_t ro_lang = {.locale_name = "ro",
 
                                        .locale_plural_fn = ro_plural_fn};
 
-static const lv_i18n_phrase_t ru_singulars[] = {
+static lv_i18n_phrase_t ru_singulars[] = {
     {"no new messages", "нет новых сообщений"},
     {"1 of 1 nodes online", "1 из 1 узлов онлайн"},
     {"DEL", "DEL"},
@@ -1728,7 +1705,7 @@ static const lv_i18n_lang_t ru_lang = {.locale_name = "ru",
 
                                        .locale_plural_fn = ru_plural_fn};
 
-static const lv_i18n_phrase_t se_singulars[] = {
+static lv_i18n_phrase_t se_singulars[] = {
     {"no new messages", "inga nya meddelanden"},
     {"1 of 1 nodes online", "1 av 1 noder online"},
     {"uptime 00:00:00", "upptid 00:00:00"},
@@ -1859,11 +1836,11 @@ static const lv_i18n_phrase_t se_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t se_plurals_one[] = {
+static lv_i18n_phrase_t se_plurals_one[] = {
     {"%d active chat(s)", "1 aktiv chatt"}, {"%d of %d nodes online", "1 nod online"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t se_plurals_other[] = {
+static lv_i18n_phrase_t se_plurals_other[] = {
     {"%d active chat(s)", "%d aktiva chattar"}, {"%d of %d nodes online", "%d av %d noder online"}, {NULL, NULL} // End mark
 };
 
@@ -1885,7 +1862,7 @@ static const lv_i18n_lang_t se_lang = {.locale_name = "se",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = se_plurals_other,
                                        .locale_plural_fn = se_plural_fn};
 
-static const lv_i18n_phrase_t sl_singulars[] = {
+static lv_i18n_phrase_t sl_singulars[] = {
     {"User name: %s", "Uporabniško ime: %s"},
     {"Device Role: %s", "Vloga: %s"},
     {"no new messages", "ni novih sporočil"},
@@ -2025,11 +2002,11 @@ static const lv_i18n_phrase_t sl_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t sl_plurals_one[] = {
+static lv_i18n_phrase_t sl_plurals_one[] = {
     {"%d of %d nodes online", "1 vozlišč povezano"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t sl_plurals_other[] = {
+static lv_i18n_phrase_t sl_plurals_other[] = {
     {"%d of %d nodes online", "%d / %d vozl. povezanih"}, {NULL, NULL} // End mark
 };
 
@@ -2057,7 +2034,7 @@ static const lv_i18n_lang_t sl_lang = {.locale_name = "sl",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = sl_plurals_other,
                                        .locale_plural_fn = sl_plural_fn};
 
-static const lv_i18n_phrase_t sr_singulars[] = {
+static lv_i18n_phrase_t sr_singulars[] = {
     {"no new messages", "nema novih poruka"},
     {"1 of 1 nodes online", "1 od 1 nodova online"},
     {"uptime 00:00:00", "uključen pre 00:00:00"},
@@ -2211,7 +2188,7 @@ static const lv_i18n_lang_t sr_lang = {.locale_name = "sr",
 
                                        .locale_plural_fn = sr_plural_fn};
 
-static const lv_i18n_phrase_t tr_singulars[] = {
+static lv_i18n_phrase_t tr_singulars[] = {
     {"no new messages", "Yeni mesaj yok"},
     {"1 of 1 nodes online", "1/1 düğüm aktif"},
     {"uptime 00:00:00", "Çalışma süresi %s"},
@@ -2341,11 +2318,11 @@ static const lv_i18n_phrase_t tr_singulars[] = {
     {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t tr_plurals_one[] = {
+static lv_i18n_phrase_t tr_plurals_one[] = {
     {"%d of %d nodes online", "1 düğüm çevrimiçi"}, {NULL, NULL} // End mark
 };
 
-static const lv_i18n_phrase_t tr_plurals_other[] = {
+static lv_i18n_phrase_t tr_plurals_other[] = {
     {"%d of %d nodes online", "%d / %d düğümler çevrimiçi"}, {NULL, NULL} // End mark
 };
 
@@ -2365,7 +2342,7 @@ static const lv_i18n_lang_t tr_lang = {.locale_name = "tr",
                                        .plurals[LV_I18N_PLURAL_TYPE_OTHER] = tr_plurals_other,
                                        .locale_plural_fn = tr_plural_fn};
 
-static const lv_i18n_phrase_t zh_cn_singulars[] = {
+static lv_i18n_phrase_t zh_cn_singulars[] = {
     {"no new messages", "暂无新消息"},
     {"1 of 1 nodes online", "1/1 个节点在线"},
     {"DEL", "删除"},
@@ -2550,14 +2527,6 @@ int lv_i18n_init(const lv_i18n_language_pack_t *langs)
 }
 
 /**
- * Sugar for simplified `lv_i18n_init` call
- */
-int lv_i18n_init_default(void)
-{
-    return lv_i18n_init(lv_i18n_language_pack);
-}
-
-/**
  * Change the localization (language)
  * @param l_name name of the translation locale to use. E.g. "en-GB"
  */
@@ -2579,12 +2548,12 @@ int lv_i18n_set_locale(const char *l_name)
     return -1;
 }
 
-static const char *__lv_i18n_get_text_core(const lv_i18n_phrase_t *trans, const char *msg_id)
+static const char *__lv_i18n_get_text_core(lv_i18n_phrase_t *trans, const char *msg_id)
 {
     uint16_t i;
     for (i = 0; trans[i].msg_id != NULL; i++) {
         if (strcmp(trans[i].msg_id, msg_id) == 0) {
-            /*The msg_id has been found. Check the translation*/
+            /*The msg_id has found. Check the translation*/
             if (trans[i].translation)
                 return trans[i].translation;
         }

--- a/locale/lv_i18n.h
+++ b/locale/lv_i18n.h
@@ -25,8 +25,8 @@ typedef struct {
 
 typedef struct {
     const char *locale_name;
-    const lv_i18n_phrase_t *singulars;
-    const lv_i18n_phrase_t *plurals[_LV_I18N_PLURAL_TYPE_NUM];
+    lv_i18n_phrase_t *singulars;
+    lv_i18n_phrase_t *plurals[_LV_I18N_PLURAL_TYPE_NUM];
     uint8_t (*locale_plural_fn)(int32_t num);
 } lv_i18n_lang_t;
 
@@ -40,11 +40,6 @@ extern const lv_i18n_language_pack_t lv_i18n_language_pack[];
  * @param langs pointer to the array of languages. (Last element has to be `NULL`)
  */
 int lv_i18n_init(const lv_i18n_language_pack_t *langs);
-
-/**
- * Sugar for simplified `lv_i18n_init` call
- */
-int lv_i18n_init_default(void);
 
 /**
  * Change the localization (language)


### PR DESCRIPTION
- Regenerated en.yml using lv_i18n extract to ensure up-to-date entries.
- Enclosed lines containing \n in double quotes (") for correct parsing.
- Updated Greek translation with the latest extracted lines.
- Fixed issue (el.yaml) with the SD card status.