### PR TITLE
feat: set fixed_position using MUI map home position

### DIFF
--- a/include/graphics/common/ViewController.h
+++ b/include/graphics/common/ViewController.h
@@ -37,6 +37,7 @@ class ViewController
     virtual bool sendConfig(const meshtastic_User &user, uint32_t nodeId = 0);
     virtual bool sendConfig(meshtastic_Config_DeviceConfig &&device, uint32_t nodeId = 0);
     virtual bool sendConfig(meshtastic_Config_PositionConfig &&position, uint32_t nodeId = 0);
+    virtual bool sendConfig(meshtastic_Position &&position, uint32_t nodeId = 0);
     virtual bool sendConfig(meshtastic_Config_PowerConfig &&power, uint32_t nodeId = 0);
     virtual bool sendConfig(meshtastic_Config_NetworkConfig &&network, uint32_t nodeId = 0);
     virtual bool sendConfig(meshtastic_Config_DisplayConfig &&display, uint32_t nodeId = 0);

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2216,10 +2216,17 @@ void TFTView_320x240::ui_event_navHome(lv_event_t *e)
         THIS->map->getHomeLocation(lat, lon);
         THIS->db.uiConfig.has_map_data = true;
         THIS->db.uiConfig.map_data.has_home = true;
-        THIS->db.uiConfig.map_data.home.latitude = lat * 1e7;
-        THIS->db.uiConfig.map_data.home.longitude = lon * 1e7;
+        THIS->db.uiConfig.map_data.home.latitude = lat * 1e7f;
+        THIS->db.uiConfig.map_data.home.longitude = lon * 1e7f;
         THIS->db.uiConfig.map_data.home.zoom = MapTileSettings::getZoomLevel();
         THIS->controller->storeUIConfig(THIS->db.uiConfig);
+
+        if (THIS->db.config.position.fixed_position) {
+            THIS->controller->sendConfig(meshtastic_Position{.latitude_i = (int32_t)(lat * 1e7f),
+                                                             .longitude_i = (int32_t)(lon * 1e7f),
+                                                             .time = uint32_t(VALID_TIME(THIS->actTime) ? THIS->actTime : 0),
+                                                             .location_source = meshtastic_Position_LocSource_LOC_MANUAL});
+        }
     }
 }
 

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2214,18 +2214,27 @@ void TFTView_320x240::ui_event_navHome(lv_event_t *e)
         float lat, lon;
         THIS->map->setHomePosition();
         THIS->map->getHomeLocation(lat, lon);
+
+        int32_t ilat = lat * 1e7f;
+        int32_t ilon = lon * 1e7f;
         THIS->db.uiConfig.has_map_data = true;
         THIS->db.uiConfig.map_data.has_home = true;
-        THIS->db.uiConfig.map_data.home.latitude = lat * 1e7f;
-        THIS->db.uiConfig.map_data.home.longitude = lon * 1e7f;
+        THIS->db.uiConfig.map_data.home.latitude = ilat;
+        THIS->db.uiConfig.map_data.home.longitude = ilon;
         THIS->db.uiConfig.map_data.home.zoom = MapTileSettings::getZoomLevel();
         THIS->controller->storeUIConfig(THIS->db.uiConfig);
 
-        if (THIS->db.config.position.fixed_position) {
-            THIS->controller->sendConfig(meshtastic_Position{.latitude_i = (int32_t)(lat * 1e7f),
-                                                             .longitude_i = (int32_t)(lon * 1e7f),
-                                                             .time = uint32_t(VALID_TIME(THIS->actTime) ? THIS->actTime : 0),
-                                                             .location_source = meshtastic_Position_LocSource_LOC_MANUAL});
+        meshtastic_Config_PositionConfig &position = THIS->db.config.position;
+        if (position.fixed_position) {
+            THIS->updatePosition(THIS->ownNode, ilat, ilon, 0, 0, 0);
+            if (position.gps_mode != meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT) {
+                // grey out text to indicate it's a fixed position vs. actual GPS position
+                Themes::recolorText(objects.home_location_label, false);
+                THIS->controller->sendConfig(meshtastic_Position{.latitude_i = ilat,
+                                                                 .longitude_i = ilon,
+                                                                 .time = uint32_t(VALID_TIME(THIS->actTime) ? THIS->actTime : 0),
+                                                                 .location_source = meshtastic_Position_LocSource_LOC_MANUAL});
+            }
         }
     }
 }
@@ -5490,8 +5499,14 @@ void TFTView_320x240::updatePositionConfig(const meshtastic_Config_PositionConfi
 {
     db.config.position = cfg;
     db.config.has_position = true;
+    if (cfg.gps_mode != meshtastic_Config_PositionConfig_GpsMode_NOT_PRESENT) {
+        if (cfg.fixed_position && db.uiConfig.map_data.has_home) {
+            updatePosition(ownNode, db.uiConfig.map_data.home.latitude, db.uiConfig.map_data.home.longitude, 0, 0, 0);
+        }
+        // grey out text to indicate it's a fixed position vs. actual GPS position
+        Themes::recolorText(objects.home_location_label, !cfg.fixed_position);
+    }
     Themes::recolorButton(objects.home_location_button, cfg.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED);
-    Themes::recolorText(objects.home_location_label, cfg.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED);
 }
 
 void TFTView_320x240::updatePowerConfig(const meshtastic_Config_PowerConfig &cfg)

--- a/source/graphics/common/ViewController.cpp
+++ b/source/graphics/common/ViewController.cpp
@@ -209,6 +209,14 @@ bool ViewController::sendConfig(meshtastic_Config_PositionConfig &&position, uin
                             nodeId ? nodeId : myNodeNum);
 }
 
+bool ViewController::sendConfig(meshtastic_Position &&position, uint32_t nodeId)
+{
+    return sendAdminMessage(meshtastic_AdminMessage{.which_payload_variant = meshtastic_AdminMessage_set_fixed_position_tag,
+                                                    .set_fixed_position{position}},
+                            nodeId ? nodeId : myNodeNum);
+
+}
+
 bool ViewController::sendConfig(meshtastic_Config_PowerConfig &&power, uint32_t nodeId)
 {
     return sendAdminMessage(meshtastic_AdminMessage{.which_payload_variant = meshtastic_AdminMessage_set_config_tag,

--- a/source/graphics/common/ViewController.cpp
+++ b/source/graphics/common/ViewController.cpp
@@ -214,7 +214,6 @@ bool ViewController::sendConfig(meshtastic_Position &&position, uint32_t nodeId)
     return sendAdminMessage(meshtastic_AdminMessage{.which_payload_variant = meshtastic_AdminMessage_set_fixed_position_tag,
                                                     .set_fixed_position{position}},
                             nodeId ? nodeId : myNodeNum);
-
 }
 
 bool ViewController::sendConfig(meshtastic_Config_PowerConfig &&power, uint32_t nodeId)


### PR DESCRIPTION
set fixed_position lat/lon (if enabled) during setting home position if this switch has been enabled
fixed position is displayed as greyed out to distinguish from actual GPS readings which are colored

closes #62