### PR TITLE
fix: add stack protector to cope with array index issues of touch driver

### DIFF
--- a/include/graphics/LGFX/LGFX_INDICATOR.h
+++ b/include/graphics/LGFX/LGFX_INDICATOR.h
@@ -36,11 +36,16 @@ class LGFX_Touch : public lgfx::LGFX_Device
 
     bool getTouchXY(uint16_t *touchX, uint16_t *touchY)
     {
+        char stackProtector1[32];
         TOUCHINFO ti;
-        if (bbct.getSamples(&ti) && (ti.x[0] || ti.y[0]) && ti.x[0] < 480 && ti.y[0] < 480) {
-            *touchX = ti.x[0];
-            *touchY = ti.y[0];
-            return true;
+        char stackProtector2[32];
+
+        if (bbct.getSamples(&ti)) {
+            if ((ti.x[0] || ti.y[0]) && ti.x[0] < 480 && ti.y[0] < 480) {
+                *touchX = ti.x[0];
+                *touchY = ti.y[0];
+                return true;
+            }
         }
         return false;
     };


### PR DESCRIPTION
fixes #68 (workaround)
```
0x40377d92: panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c:408
0x403816fd: esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/esp_system.c:137
0x403773da: __stack_chk_fail at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/stack_check.c:35
0x42051d79: LGFXDriver<LGFX_INDICATOR>::touchpad_read(_lv_indev_t*, lv_indev_data_t*) at :?
0x42033396: lv_indev_read_timer_cb at :?
0x4202e346: lv_timer_periodic_handler at ??:?


0x40377e26: panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c:408
0x403817b1: esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/esp_system.c:137
0x4037746e: __stack_chk_fail at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/stack_check.c:35
0x42007842: BBCapTouch::getSamples(_fttouchinfo*) at /home/manuel/Documents/PlatformIO/Projects/meshtastic-latest/.pio/libdeps/seeed-sensecap-indicator-tft/bb_captouch/src/bb_captouch.cpp:572
0x4205a83d: LGFX_Touch::getTouchXY(unsigned short*, unsigned short*) at /home/manuel/Documents/PlatformIO/Projects/device-ui/include/graphics/LGFX/LGFX_INDICATOR.h:46
 (inlined by) LGFXDriver<LGFX_INDICATOR>::touchpad_read(_lv_indev_t*, lv_indev_data_t*) at /home/manuel/Documents/PlatformIO/Projects/device-ui/include/graphics/driver/LGFXDriver.h:198
0x42032b96: indev_read_core at /home/manuel/Documents/PlatformIO/Projects/meshtastic-latest/.pio/libdeps/seeed-sensecap-indicator-tft/lvgl/src/indev/lv_indev.c:197
```