### PR TITLE
feat: Linux frame buffer support

### DIFF
--- a/include/graphics/driver/DisplayDriverConfig.h
+++ b/include/graphics/driver/DisplayDriverConfig.h
@@ -21,6 +21,8 @@ class DisplayDriverConfig
         CUSTOM_OLED,
         CUSTOM_EINK,
         X11,
+        SDL,
+        FB,
         THMI,
         TDECK,
         INDICATOR,

--- a/include/graphics/driver/FBDriver.h
+++ b/include/graphics/driver/FBDriver.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "graphics/driver/DisplayDriver.h"
+
+/**
+ * @brief For simulation on pc/raspberry
+ * This class provides an FB GUI on the local desktop; dimensions are defined
+ * in lv_drv_conf.h Usage: define USE_FB=1 for the rasbian/portduino target and
+ * link with -lFB
+ */
+class FBDriver : public DisplayDriver
+{
+  public:
+    static FBDriver &create(uint16_t width, uint16_t height);
+    void init(DeviceGUI *gui) override;
+    virtual ~FBDriver() {}
+
+  private:
+    FBDriver(uint16_t width, uint16_t height);
+
+#if LV_USE_EVDEV
+    static void discovery_cb(lv_indev_t *indev, lv_evdev_type_t type, void *user_data);
+    static void set_mouse_cursor_icon(lv_indev_t *indev, lv_display_t *display);
+    static void indev_deleted_cb(lv_event_t *e);
+#endif
+
+    static FBDriver *fbDriver;
+    static lv_display_t* display;
+};

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -1040,7 +1040,7 @@
 #endif
 
 /*Driver for /dev/fb*/
-#define LV_USE_LINUX_FBDEV      0
+#define LV_USE_LINUX_FBDEV      USE_FRAMEBUFFER
 #if LV_USE_LINUX_FBDEV
     #define LV_LINUX_FBDEV_BSD           0
     #define LV_LINUX_FBDEV_RENDER_MODE   LV_DISPLAY_RENDER_MODE_PARTIAL
@@ -1076,7 +1076,9 @@
 #define LV_USE_TFT_ESPI         0
 
 /*Driver for evdev input devices*/
+#ifndef LV_USE_EVDEV
 #define LV_USE_EVDEV    0
+#endif
 
 /*Driver for libinput input devices*/
 #ifndef LV_USE_LIBINPUT

--- a/source/graphics/driver/DisplayDriverFactory.cpp
+++ b/source/graphics/driver/DisplayDriverFactory.cpp
@@ -10,6 +10,9 @@
 #if defined(EINK_DRIVER) || defined(ARCH_PORTDUINO)
 // TODO #include "graphics/driver/EINKDriver.h"
 #endif
+#if defined(USE_FRAMEBUFFER)
+#include "graphics/driver/FBDriver.h"
+#endif
 #if defined(USE_X11)
 #include "graphics/driver/X11Driver.h"
 #endif
@@ -66,6 +69,9 @@ DisplayDriverFactory::DisplayDriverFactory() {}
 
 DisplayDriver *DisplayDriverFactory::create(uint16_t width, uint16_t height)
 {
+#if defined(USE_FRAMEBUFFER)
+    return &FBDriver::create(width, height);
+#endif
 #if defined(USE_X11)
     return &X11Driver::create(width, height);
 #elif defined(LGFX_DRIVER)
@@ -92,6 +98,11 @@ DisplayDriver *DisplayDriverFactory::create(const DisplayDriverConfig &cfg)
 #if defined(EINKConfig) || defined(ARCH_PORTDUINO)
     if (cfg._device == DisplayDriverConfig::device_t::CUSTOM_EINK) {
         // TODO return new EINKDriver<EINKConfig>(cfg);
+    }
+#endif
+#if defined(USE_FRAMEBUFFER)
+    if (cfg._device == DisplayDriverConfig::device_t::FB) {
+        return &FBDriver::create(cfg.width(), cfg.height());
     }
 #endif
 #if defined(USE_X11)
@@ -153,6 +164,10 @@ DisplayDriver *DisplayDriverFactory::create(const DisplayDriverConfig &cfg)
         return new LGFXDriver<LGFX_ESP2432S028RV2>(cfg.width(), cfg.height());
         break;
 #endif
+#elif defined(USE_FRAMEBUFFER)
+    case DisplayDriverConfig::device_t::FB:
+        return &FBDriver::create(cfg.width(), cfg.height());
+        break;
 #elif defined(USE_X11)
     case DisplayDriverConfig::device_t::X11:
         return &X11Driver::create(cfg.width(), cfg.height());

--- a/source/graphics/driver/FBDriver.cpp
+++ b/source/graphics/driver/FBDriver.cpp
@@ -1,0 +1,81 @@
+#ifdef USE_FRAMEBUFFER
+
+#include "graphics/driver/FBDriver.h"
+#include "util/ILog.h"
+#include "src/core/lv_global.h"
+
+
+LV_IMG_DECLARE(mouse_cursor_icon);
+
+FBDriver *FBDriver::fbDriver = nullptr;
+lv_display_t *FBDriver::display = nullptr;
+
+FBDriver &FBDriver::create(uint16_t width, uint16_t height)
+{
+    if (!fbDriver)
+        fbDriver = new FBDriver(width, height);
+    return *fbDriver;
+}
+
+FBDriver::FBDriver(uint16_t width, uint16_t height) : DisplayDriver(width, height) {}
+
+void FBDriver::init(DeviceGUI *gui)
+{
+    ILOG_DEBUG("FBDriver::init...");
+    // Initialize LVGL
+    DisplayDriver::init(gui);
+
+    // Linux frame buffer device init
+    const char *device = getenv("LV_LINUX_FBDEV_DEVICE");
+    device = (device != nullptr && strlen(device) > 0) ? device : "/dev/fb0";
+    display = lv_linux_fbdev_create();
+
+    if (display == nullptr) {
+        ILOG_CRIT("Failed to initialize %d", device);
+        return;
+    }
+    lv_linux_fbdev_set_file(display, device);
+
+#if LV_USE_EVDEV
+    // discover input devices
+    lv_evdev_discovery_start(discovery_cb, display);
+#endif
+}
+
+#if LV_USE_EVDEV
+void FBDriver::discovery_cb(lv_indev_t *indev, lv_evdev_type_t type, void *user_data)
+{
+    ILOG_INFO("'%s' device discovered", type == LV_EVDEV_TYPE_REL ? "REL" :
+                                        type == LV_EVDEV_TYPE_ABS ? "ABS" :
+                                        type == LV_EVDEV_TYPE_KEY ? "KEY" :
+                                        "???");
+
+    lv_display_t *disp = (lv_display_t *)user_data;
+    lv_indev_set_display(indev, disp);
+
+    if(type == LV_EVDEV_TYPE_REL) {
+        set_mouse_cursor_icon(indev, disp);
+    }
+}
+
+void FBDriver::set_mouse_cursor_icon(lv_indev_t *indev, lv_display_t *display)
+{
+    // Set the cursor icon
+    LV_IMAGE_DECLARE(mouse_cursor_icon);
+    lv_obj_t *cursor_obj = lv_image_create(lv_display_get_screen_active(display));
+    lv_image_set_src(cursor_obj, &mouse_cursor_icon);
+    lv_indev_set_cursor(indev, cursor_obj);
+
+    // delete the mouse cursor icon if the device is removed
+    lv_indev_add_event_cb(indev, indev_deleted_cb, LV_EVENT_DELETE, cursor_obj);
+}
+
+void FBDriver::indev_deleted_cb(lv_event_t *e)
+{
+    if(LV_GLOBAL_DEFAULT()->deinit_in_progress) return;
+    lv_obj_t *cursor_obj = (lv_obj_t*)lv_event_get_user_data(e);
+    lv_obj_del(cursor_obj);
+}
+#endif
+
+#endif

--- a/source/input/LinuxInputDriver.cpp
+++ b/source/input/LinuxInputDriver.cpp
@@ -1,4 +1,4 @@
-#ifdef ARCH_PORTDUINO
+#if defined(ARCH_PORTDUINO) && LV_USE_LIBINPUT
 
 #include "input/LinuxInputDriver.h"
 #include "screens.h"


### PR DESCRIPTION
Direct control for DSI TFT screens via /dev/fb0.

In native target define:
```
  -D USE_FRAMEBUFFER=1
  -D LV_COLOR_DEPTH=32
  -D LV_USE_EVDEV=1
```

and remove 
```
  -D USE_X11=1
  -D LV_USE_LIBINPUT=1
  -lX11 -linput -lxkbcommon
```
