### PR TITLE
fix: channel num

### DIFF
--- a/include/graphics/common/LoRaPresets.h
+++ b/include/graphics/common/LoRaPresets.h
@@ -16,7 +16,8 @@ class LoRaPresets
     static float getFrequencyStart(meshtastic_Config_LoRaConfig_RegionCode region);
     static float getFrequencyEnd(meshtastic_Config_LoRaConfig_RegionCode region);
     static uint16_t getDefaultSlot(meshtastic_Config_LoRaConfig_RegionCode region,
-                                   meshtastic_Config_LoRaConfig_ModemPreset preset);
+                                   meshtastic_Config_LoRaConfig_ModemPreset preset,
+                                   const char* channelName = nullptr);
 
     struct ModemPreset {
         const char *preset;

--- a/include/graphics/view/TFT/TFTView_320x240.h
+++ b/include/graphics/view/TFT/TFTView_320x240.h
@@ -431,5 +431,5 @@ class TFTView_320x240 : public MeshtasticView
         meshtastic_DeviceConnectionStatus connectionStatus; // wifi/bluetooth/ethernet
     };
 
-    meshtastic_DeviceProfile_full db; // full copy of the node's configuration db (except nodeinfos) plus ui data
+    meshtastic_DeviceProfile_full db{}; // full copy of the node's configuration db (except nodeinfos) plus ui data
 };

--- a/source/graphics/common/LoRaPresets.cpp
+++ b/source/graphics/common/LoRaPresets.cpp
@@ -36,7 +36,8 @@ float LoRaPresets::getFrequencyEnd(meshtastic_Config_LoRaConfig_RegionCode regio
  * Default slot number is generated using the same firmware hash algorithm
  */
 uint16_t LoRaPresets::getDefaultSlot(meshtastic_Config_LoRaConfig_RegionCode region,
-                                     meshtastic_Config_LoRaConfig_ModemPreset preset)
+                                     meshtastic_Config_LoRaConfig_ModemPreset preset,
+                                     const char* channelName)
 {
     auto hash = [](const char *str) -> uint32_t {
         uint32_t hash = 5381;
@@ -47,7 +48,7 @@ uint16_t LoRaPresets::getDefaultSlot(meshtastic_Config_LoRaConfig_RegionCode reg
     };
 
     uint32_t numChannels = getNumChannels(region, preset);
-    return numChannels == 0 ? 1 : hash(modemPreset[preset].preset) % numChannels + 1;
+    return numChannels == 0 ? 1 : hash(channelName ? channelName : modemPreset[preset].preset) % numChannels + 1;
 }
 
 float LoRaPresets::getBandwidth(meshtastic_Config_LoRaConfig_ModemPreset preset)


### PR DESCRIPTION
- consider actual channel name for hash calculation
- use previous channel num if region is UNSET (e.g. set via userPrefs)