### PR TITLE
feat: USERPREFS - Customize background color

### DIFF
--- a/generated/ui_320x240/screens.c
+++ b/generated/ui_320x240/screens.c
@@ -20,7 +20,13 @@ void create_screen_boot_screen() {
     lv_obj_set_size(obj, 320, 240);
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_style_text_font(obj, &ui_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_bg_color(obj, lv_color_hex(0xff67ea94), LV_PART_MAIN | LV_STATE_DEFAULT);
+    int bg_color;
+    #ifdef USERPREFS_TFT_COLOR_BG
+    bg_color = lv_color_hex(USERPREFS_TFT_COLOR_BG);
+    #else
+    bg_color = lv_color_hex(0xff67ea94);
+    #endif
+    lv_obj_set_style_bg_color(obj, bg_color, LV_PART_MAIN | LV_STATE_DEFAULT);
     {
         lv_obj_t *parent_obj = obj;
         {


### PR DESCRIPTION
DRAFT untested.

Make Background color configurable from `USERPREFS`.

The `ff67ea94` color does not play nice with the DefCon 33 logo :skull_and_crossbones:  
![image](https://github.com/user-attachments/assets/df67822b-38ec-4d19-84b5-44d898742ba0)
