### PR TITLE
feat(LGFX_GENERIC): add conditional hasButton() method based on HAS_BUTTON macro

### DIFF
--- a/include/graphics/LGFX/LGFX_GENERIC.h
+++ b/include/graphics/LGFX/LGFX_GENERIC.h
@@ -204,7 +204,7 @@ class LGFX_GENERIC : public lgfx::LGFX_Device
     const uint32_t screenWidth = LGFX_SCREEN_WIDTH;
     const uint32_t screenHeight = LGFX_SCREEN_HEIGHT;
 
-#ifdef HAS_BUTTON
+#ifdef LGFX_HAS_BUTTON
     bool hasButton(void) { return true; }
 #else
     bool hasButton(void) { return false; }

--- a/include/graphics/LGFX/LGFX_GENERIC.h
+++ b/include/graphics/LGFX/LGFX_GENERIC.h
@@ -204,7 +204,11 @@ class LGFX_GENERIC : public lgfx::LGFX_Device
     const uint32_t screenWidth = LGFX_SCREEN_WIDTH;
     const uint32_t screenHeight = LGFX_SCREEN_HEIGHT;
 
+#ifdef HAS_BUTTON
+    bool hasButton(void) { return true; }
+#else
     bool hasButton(void) { return false; }
+#endif
 
     LGFX_GENERIC(void)
     {


### PR DESCRIPTION
This pull request introduces a conditional method to the `LGFX_GENERIC` class to determine the presence of a button, based on the `HAS_BUTTON` macro.

Key change:

* [`include/graphics/LGFX/LGFX_GENERIC.h`](diffhunk://#diff-809f75f762633523ada31e1925d015eb8c194cf0891600f25ba0cc704f34934dR207-R211): Added a conditional implementation of the `hasButton` method in the `LGFX_GENERIC` class. The method now returns `true` if the `HAS_BUTTON` macro is defined, and `false` otherwise.