### PR TITLE
build: Switch to lvgl 9.3.0 in PlatformIO Registry

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,7 +21,7 @@
   "headers": ["DeviceScreen.h", "SharedQueue.h"],
   "dependencies": {
     "ArduinoThread": "https://github.com/meshtastic/ArduinoThread/archive/7c3ee9e1951551b949763b1f5280f8db1fa4068d.zip",
-    "lvgl/lvgl": "https://github.com/lvgl/lvgl/archive/9c043167685fc08fbcd30ddf2c285ea1089be82d.zip",
+    "lvgl/lvgl": "9.3.0",
     "greiman/SdFat": "https://github.com/mverch67/SdFat/archive/152a52251fc5e1d581303b42378ea712ab229246.zip",
     "nanopb/Nanopb": "0.4.91"
   },


### PR DESCRIPTION
Switch to PlatformIO lvgl releases.
v9.3.0 includes the commit that we were previously referencing directly.

Crucially these do *not* include demos / examples; Thus, lvgl installed from the Platformio Registry uses 77 MB, whereas lvgl installed from the git archive uses 204 MB.

@mverch67 let's try to stay on PlatformIO Registry releases going forward :pray: the CI thanks you. (If a need arises, we could instead create an archive zip that doesn't bundle demos ourselves)