### PR TITLE
Dependencies: Switch to zips from github

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,9 +21,9 @@
   "headers": ["DeviceScreen.h", "SharedQueue.h"],
   "dependencies": {
     "ArduinoThread": "https://github.com/meshtastic/ArduinoThread/archive/7c3ee9e1951551b949763b1f5280f8db1fa4068d.zip",
-    "lvgl/lvgl": "9.3.0",
+    "lvgl/lvgl": "https://github.com/lvgl/lvgl/archive/refs/tags/v9.3.0.zip",
     "greiman/SdFat": "https://github.com/mverch67/SdFat/archive/152a52251fc5e1d581303b42378ea712ab229246.zip",
-    "nanopb/Nanopb": "0.4.91"
+    "nanopb/Nanopb": "https://github.com/nanopb/nanopb/archive/refs/tags/nanopb-0.4.9.1.zip"
   },
   "build": {
     "libArchive": true,


### PR DESCRIPTION
PlatformIO is (probably) rate limiting us. Workaround this by using GitHub zips instead.