### PR TITLE
fix: validate channel index to prevent OOB crash on TFT devices

### DIFF
--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -6351,6 +6351,10 @@ void TFTView_320x240::updateTime(uint32_t timeVal)
  */
 lv_obj_t *TFTView_320x240::newMessageContainer(uint32_t from, uint32_t to, uint8_t ch)
 {
+    if (ch >= c_max_channels) {
+        ILOG_WARN("newMessageContainer: invalid channel %d", ch);
+        return nullptr;
+    }
     if (to == UINT32_MAX || from == 0) {
         if (channelGroup[ch] != nullptr)
             return channelGroup[ch];
@@ -6407,6 +6411,10 @@ lv_obj_t *TFTView_320x240::newMessageContainer(uint32_t from, uint32_t to, uint8
  */
 void TFTView_320x240::newMessage(uint32_t from, uint32_t to, uint8_t ch, const char *msg, uint32_t &msgTime, bool restore)
 {
+    if (ch >= c_max_channels) {
+        ILOG_WARN("newMessage(6-arg): invalid channel %d, skipping", ch);
+        return;
+    }
     ILOG_DEBUG("newMessage: from:0x%08x, to:0x%08x, ch:%d, time:%d", from, to, ch, msgTime);
     int pos = 0;
     char buf[284]; // 237 + 4 + 40 + 2 + 1
@@ -6468,6 +6476,7 @@ void TFTView_320x240::newMessage(uint32_t from, uint32_t to, uint8_t ch, const c
  */
 void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t ch, const char *msg)
 {
+    if (!container) return;
     lv_obj_t *hiddenPanel = lv_obj_create(container);
     lv_obj_set_width(hiddenPanel, lv_pct(100));
     lv_obj_set_height(hiddenPanel, LV_SIZE_CONTENT); /// 50
@@ -6501,6 +6510,10 @@ void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t 
  */
 void TFTView_320x240::restoreMessage(const LogMessage &msg)
 {
+    if (msg.ch >= c_max_channels) {
+        ILOG_WARN("restoreMessage: skip invalid ch=%d", msg.ch);
+        return;
+    }
     //((uint8_t *)msg.bytes)[msg._size] = 0;
     // ILOG_DEBUG("restoring msg from:0x%08x, to:0x%08x, ch:%d, time:%d, status:%d, trash:%d, size:%d, '%s'", msg.from, msg.to,
     //           msg.ch, msg.time, (int)msg.status, msg.trashFlag, msg._size, msg.bytes);
@@ -6559,6 +6572,7 @@ void TFTView_320x240::restoreMessage(const LogMessage &msg)
         buf[pos + len + msg.length()] = 0;
 
         lv_obj_t *container = newMessageContainer(msg.from, msg.to, msg.ch);
+        if (!container) return;
         lv_obj_add_flag(container, LV_OBJ_FLAG_HIDDEN);
         newMessage(msg.from, container, msg.ch, buf);
     }
@@ -6654,7 +6668,7 @@ void TFTView_320x240::addChat(uint32_t from, uint32_t to, uint8_t ch)
 
     chats[index] = chatBtn;
     updateActiveChats();
-    if (index > c_max_channels) {
+    if (index >= c_max_channels) {
         if (nodes.find(index) != nodes.end())
             applyNodesFilter(index);
     }
@@ -6742,6 +6756,10 @@ void TFTView_320x240::showMessages(uint8_t ch)
         return;
     }
 
+    if (ch >= c_max_channels) {
+        ILOG_WARN("showMessages: invalid channel %d", ch);
+        return;
+    }
     lv_obj_add_flag(activeMsgContainer, LV_OBJ_FLAG_HIDDEN);
     activeMsgContainer = channelGroup[ch];
     if (!activeMsgContainer) {

--- a/source/graphics/common/ViewController.cpp
+++ b/source/graphics/common/ViewController.cpp
@@ -642,6 +642,10 @@ void ViewController::restoreTextMessages(void)
     LogMessageEnv msg;
 
     if (log.readNext(msg)) {
+        if (msg.ch >= c_max_channels) {
+            ILOG_WARN("skipping stored message with invalid channel %d", msg.ch);
+            return;
+        }
         msgCounter++;
         msgTotalSize += msg.size();
         view->restoreMessage(msg);
@@ -935,6 +939,10 @@ bool ViewController::packetReceived(const meshtastic_MeshPacket &p)
             }
         }
         uint32_t time = p.rx_time;
+        if (p.channel >= c_max_channels) {
+            ILOG_WARN("ignoring message with invalid channel %d", p.channel);
+            break;
+        }
         view->newMessage(p.from, p.to, p.channel, (const char *)p.decoded.payload.bytes, time);
         log.write(LogMessageEnv(p.from, p.to, p.channel, time, LogMessage::eDefault, false, p.decoded.payload.size,
                                 (const uint8_t *)p.decoded.payload.bytes));


### PR DESCRIPTION
Fixes #304

## What

Add `ch >= c_max_channels` bounds checks at both `ViewController` entry points before any `channelGroup` access, plus defensive guards inside `TFTView_320x240` messaging functions.

## Changes

**`ViewController.cpp`** (root fix)
- `restoreTextMessages()`: skip stored messages with invalid channel index
- `packetReceived()`: reject live packets with invalid channel index

**`TFTView_320x240.cpp`** (defensive guards)
- `newMessageContainer()`: return `nullptr` if `ch >= c_max_channels`
- `newMessage()` (6-arg): early return if `ch >= c_max_channels`
- `newMessage()` (4-arg): null guard on `container` before `lv_obj_create()`
- `restoreMessage()`: skip if `msg.ch >= c_max_channels`; null guard after `newMessageContainer()`
- `showMessages()`: early return if `ch >= c_max_channels`
- `addChat()`: fix off-by-one (`index > c_max_channels` → `index >= c_max_channels`)

## Testing

Tested on **Heltec V4 TFT** (meshtastic/firmware 2.7.22 compiled with this device-ui patch).

**Clean boot** (clean LittleFS):
```
[DeviceUI] loading persistent messages...
[DeviceUI] restoring 2 messages completed.
```

**OOB injection** (5× ch=31 entries written directly to LittleFS via script):
```
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] restoring messages completed
```

All 5 invalid entries intercepted, device boots normally ✅