### PR TITLE
fix: validate channel index to prevent OOB crash on TFT devices

### DIFF
--- a/include/util/LogMessage.h
+++ b/include/util/LogMessage.h
@@ -64,10 +64,11 @@ class LogMessageEnv : public LogMessage
     virtual size_t deserialize(std::function<size_t(uint8_t *, size_t)> read) override
     {
         size_t len = read((uint8_t *)&_size, sizeof(LogMessageHeader) - 8);
-        if (len) {
+        if (len && _size < messagePayloadSize) {
             len += read(bytes, _size);
             bytes[_size] = 0;
         } else {
+            _size = 0;
             bytes[0] = 0;
         }
         return len;

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -6351,6 +6351,10 @@ void TFTView_320x240::updateTime(uint32_t timeVal)
  */
 lv_obj_t *TFTView_320x240::newMessageContainer(uint32_t from, uint32_t to, uint8_t ch)
 {
+    if (ch >= c_max_channels) {
+        ILOG_WARN("newMessageContainer: invalid channel %d", ch);
+        return nullptr;
+    }
     if (to == UINT32_MAX || from == 0) {
         if (channelGroup[ch] != nullptr)
             return channelGroup[ch];
@@ -6407,6 +6411,10 @@ lv_obj_t *TFTView_320x240::newMessageContainer(uint32_t from, uint32_t to, uint8
  */
 void TFTView_320x240::newMessage(uint32_t from, uint32_t to, uint8_t ch, const char *msg, uint32_t &msgTime, bool restore)
 {
+    if (ch >= c_max_channels) {
+        ILOG_WARN("newMessage(6-arg): invalid channel %d, skipping", ch);
+        return;
+    }
     ILOG_DEBUG("newMessage: from:0x%08x, to:0x%08x, ch:%d, time:%d", from, to, ch, msgTime);
     int pos = 0;
     char buf[284]; // 237 + 4 + 40 + 2 + 1
@@ -6468,6 +6476,7 @@ void TFTView_320x240::newMessage(uint32_t from, uint32_t to, uint8_t ch, const c
  */
 void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t ch, const char *msg)
 {
+    if (!container) return;
     lv_obj_t *hiddenPanel = lv_obj_create(container);
     lv_obj_set_width(hiddenPanel, lv_pct(100));
     lv_obj_set_height(hiddenPanel, LV_SIZE_CONTENT); /// 50
@@ -6501,6 +6510,10 @@ void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t 
  */
 void TFTView_320x240::restoreMessage(const LogMessage &msg)
 {
+    if (msg.ch >= c_max_channels) {
+        ILOG_WARN("restoreMessage: skip invalid ch=%d", msg.ch);
+        return;
+    }
     //((uint8_t *)msg.bytes)[msg._size] = 0;
     // ILOG_DEBUG("restoring msg from:0x%08x, to:0x%08x, ch:%d, time:%d, status:%d, trash:%d, size:%d, '%s'", msg.from, msg.to,
     //           msg.ch, msg.time, (int)msg.status, msg.trashFlag, msg._size, msg.bytes);
@@ -6559,6 +6572,7 @@ void TFTView_320x240::restoreMessage(const LogMessage &msg)
         buf[pos + len + msg.length()] = 0;
 
         lv_obj_t *container = newMessageContainer(msg.from, msg.to, msg.ch);
+        if (!container) return;
         lv_obj_add_flag(container, LV_OBJ_FLAG_HIDDEN);
         newMessage(msg.from, container, msg.ch, buf);
     }
@@ -6654,7 +6668,7 @@ void TFTView_320x240::addChat(uint32_t from, uint32_t to, uint8_t ch)
 
     chats[index] = chatBtn;
     updateActiveChats();
-    if (index > c_max_channels) {
+    if (index >= c_max_channels) {
         if (nodes.find(index) != nodes.end())
             applyNodesFilter(index);
     }
@@ -6742,6 +6756,10 @@ void TFTView_320x240::showMessages(uint8_t ch)
         return;
     }
 
+    if (ch >= c_max_channels) {
+        ILOG_WARN("showMessages: invalid channel %d", ch);
+        return;
+    }
     lv_obj_add_flag(activeMsgContainer, LV_OBJ_FLAG_HIDDEN);
     activeMsgContainer = channelGroup[ch];
     if (!activeMsgContainer) {

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -6351,10 +6351,6 @@ void TFTView_320x240::updateTime(uint32_t timeVal)
  */
 lv_obj_t *TFTView_320x240::newMessageContainer(uint32_t from, uint32_t to, uint8_t ch)
 {
-    if (ch >= c_max_channels) {
-        ILOG_WARN("newMessageContainer: invalid channel %d", ch);
-        return nullptr;
-    }
     if (to == UINT32_MAX || from == 0) {
         if (channelGroup[ch] != nullptr)
             return channelGroup[ch];
@@ -6411,10 +6407,6 @@ lv_obj_t *TFTView_320x240::newMessageContainer(uint32_t from, uint32_t to, uint8
  */
 void TFTView_320x240::newMessage(uint32_t from, uint32_t to, uint8_t ch, const char *msg, uint32_t &msgTime, bool restore)
 {
-    if (ch >= c_max_channels) {
-        ILOG_WARN("newMessage(6-arg): invalid channel %d, skipping", ch);
-        return;
-    }
     ILOG_DEBUG("newMessage: from:0x%08x, to:0x%08x, ch:%d, time:%d", from, to, ch, msgTime);
     int pos = 0;
     char buf[284]; // 237 + 4 + 40 + 2 + 1
@@ -6476,7 +6468,6 @@ void TFTView_320x240::newMessage(uint32_t from, uint32_t to, uint8_t ch, const c
  */
 void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t ch, const char *msg)
 {
-    if (!container) return;
     lv_obj_t *hiddenPanel = lv_obj_create(container);
     lv_obj_set_width(hiddenPanel, lv_pct(100));
     lv_obj_set_height(hiddenPanel, LV_SIZE_CONTENT); /// 50
@@ -6510,10 +6501,6 @@ void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t 
  */
 void TFTView_320x240::restoreMessage(const LogMessage &msg)
 {
-    if (msg.ch >= c_max_channels) {
-        ILOG_WARN("restoreMessage: skip invalid ch=%d", msg.ch);
-        return;
-    }
     //((uint8_t *)msg.bytes)[msg._size] = 0;
     // ILOG_DEBUG("restoring msg from:0x%08x, to:0x%08x, ch:%d, time:%d, status:%d, trash:%d, size:%d, '%s'", msg.from, msg.to,
     //           msg.ch, msg.time, (int)msg.status, msg.trashFlag, msg._size, msg.bytes);
@@ -6572,7 +6559,6 @@ void TFTView_320x240::restoreMessage(const LogMessage &msg)
         buf[pos + len + msg.length()] = 0;
 
         lv_obj_t *container = newMessageContainer(msg.from, msg.to, msg.ch);
-        if (!container) return;
         lv_obj_add_flag(container, LV_OBJ_FLAG_HIDDEN);
         newMessage(msg.from, container, msg.ch, buf);
     }
@@ -6668,7 +6654,7 @@ void TFTView_320x240::addChat(uint32_t from, uint32_t to, uint8_t ch)
 
     chats[index] = chatBtn;
     updateActiveChats();
-    if (index >= c_max_channels) {
+    if (index > c_max_channels) {
         if (nodes.find(index) != nodes.end())
             applyNodesFilter(index);
     }
@@ -6756,10 +6742,6 @@ void TFTView_320x240::showMessages(uint8_t ch)
         return;
     }
 
-    if (ch >= c_max_channels) {
-        ILOG_WARN("showMessages: invalid channel %d", ch);
-        return;
-    }
     lv_obj_add_flag(activeMsgContainer, LV_OBJ_FLAG_HIDDEN);
     activeMsgContainer = channelGroup[ch];
     if (!activeMsgContainer) {

--- a/source/graphics/common/ViewController.cpp
+++ b/source/graphics/common/ViewController.cpp
@@ -642,6 +642,10 @@ void ViewController::restoreTextMessages(void)
     LogMessageEnv msg;
 
     if (log.readNext(msg)) {
+        if (msg.ch >= c_max_channels) {
+            ILOG_WARN("skipping stored message with invalid channel %d", msg.ch);
+            return;
+        }
         msgCounter++;
         msgTotalSize += msg.size();
         view->restoreMessage(msg);
@@ -935,6 +939,10 @@ bool ViewController::packetReceived(const meshtastic_MeshPacket &p)
             }
         }
         uint32_t time = p.rx_time;
+        if (p.channel >= c_max_channels) {
+            ILOG_WARN("ignoring message with invalid channel %d", p.channel);
+            break;
+        }
         view->newMessage(p.from, p.to, p.channel, (const char *)p.decoded.payload.bytes, time);
         log.write(LogMessageEnv(p.from, p.to, p.channel, time, LogMessage::eDefault, false, p.decoded.payload.size,
                                 (const uint8_t *)p.decoded.payload.bytes));

--- a/source/graphics/common/ViewController.cpp
+++ b/source/graphics/common/ViewController.cpp
@@ -643,7 +643,7 @@ void ViewController::restoreTextMessages(void)
 
     if (log.readNext(msg)) {
         if (msg.ch >= c_max_channels) {
-            ILOG_WARN("skipping stored message with invalid channel %d", msg.ch);
+            ILOG_WARN("skipping stored message with invalid channel %d", (int)msg.ch);
             return;
         }
         msgCounter++;
@@ -940,7 +940,7 @@ bool ViewController::packetReceived(const meshtastic_MeshPacket &p)
         }
         uint32_t time = p.rx_time;
         if (p.channel >= c_max_channels) {
-            ILOG_WARN("ignoring message with invalid channel %d", p.channel);
+            ILOG_WARN("ignoring message with invalid channel %d", (int)p.channel);
             break;
         }
         view->newMessage(p.from, p.to, p.channel, (const char *)p.decoded.payload.bytes, time);


### PR DESCRIPTION
Fixes #304

kodos to @bouob, for some reason I could not commit into his PR branch so I copied PR #305
 
## What

Add `ch >= c_max_channels` bounds checks at both `ViewController` entry points before any `channelGroup` access, plus defensive guards inside `TFTView_320x240` messaging functions.

## Changes

**`ViewController.cpp`** (root fix)
- `restoreTextMessages()`: skip stored messages with invalid channel index
- `packetReceived()`: reject live packets with invalid channel index

**`LogMessage.h`** (crash fix)
- `deserialize()`: _size < messagePayloadSize check added

## Testing

Tested on **Heltec V4 TFT** (meshtastic/firmware 2.7.22 compiled with this device-ui patch).
Tested on **T-Deck Plus TFT** (meshtastic/firmware 2.7.23 compiled with this device-ui patch).

**Clean boot** (clean LittleFS):
```
[DeviceUI] loading persistent messages...
[DeviceUI] restoring 2 messages completed.
```

**OOB injection** (5× ch=31 entries written directly to LittleFS via script):
```
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] skipping stored message with invalid channel 31
[DeviceUI] restoring messages completed
```

All 5 invalid entries intercepted, device boots normally ✅


```
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x4208dc52  PS      : 0x00060830  A0      : 0x82083076  A1      : 0x3fcc3940  
A2      : 0x3fcbc244  A3      : 0x3fcbc244  A4      : 0x8a561c18  A5      : 0x00000eb7  
A6      : 0x69756800  A7      : 0x00000003  A8      : 0x3fcb5b54  A9      : 0x3fcc38b0  
A10     : 0x3fced640  A11     : 0x3c33f22c  A12     : 0x3c34e361  A13     : 0x3fcd2946  
A14     : 0x3fcd290c  A15     : 0x3fcc38ec  SAR     : 0x0000001e  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x8a561c18  LBEG    : 0x40055601  LEND    : 0x4005560e  LCOUNT  : 0xffffffc7  

Backtrace: 0x4208dc4f:0x3fcc3940 0x42083073:0x3fcc3ad0 0x42083e9e:0x1895ed48 |<-CORRUPTED
```

No longer crashing when restoring text messages, device boots normally ✅
