### PR TITLE
fix: HTTPS map tile loading with bounded polling loop

### DIFF
--- a/include/graphics/map/URLService.h
+++ b/include/graphics/map/URLService.h
@@ -4,7 +4,6 @@
 #include <functional>
 
 #ifdef ARDUINO_ARCH_ESP32
-#include "HTTPClient.h" // not available on Linux/Portduino
 
 class URLService : public ITileService
 {
@@ -16,7 +15,6 @@ class URLService : public ITileService
     virtual ~URLService();
 
   private:
-    HTTPClient http;
     Callback saveCB = nullptr;
 };
 

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -6,6 +6,7 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
+#include "HTTPClient.h" // not available on Linux/Portduino
 #include "WiFi.h"
 
 // from ConvertPNG.c
@@ -20,10 +21,7 @@ URLService::~URLService() {}
 
 bool URLService::load(const char *name, void *img)
 {
-    struct HttpEndGuard {
-        decltype(http) &client;
-        ~HttpEndGuard() { client.end(); }
-    } httpGuard{http};
+    HTTPClient http;
 
     if (WiFi.status() != WL_CONNECTED) {
         ILOG_DEBUG("URLService::load skipped (WiFi not connected)");
@@ -42,7 +40,12 @@ bool URLService::load(const char *name, void *img)
         return false;
     }
 
-    http.begin(url.c_str());
+    http.setReuse(false);
+    if (!http.begin(url.c_str())) {
+        ILOG_ERROR("ERROR begin %s", url.c_str());
+        return false;
+    }
+
     int httpCode = http.GET();
     if (httpCode != HTTP_CODE_OK) {
         ILOG_ERROR("ERROR GET %s : %d", url.c_str(), httpCode);
@@ -50,11 +53,13 @@ bool URLService::load(const char *name, void *img)
     }
 
     WiFiClient *stream = http.getStreamPtr();
-    size_t len = http.getSize();
-    if (len == 0) {
+    int contentLen = http.getSize();
+    if (contentLen <= 0) {
         ILOG_WARN("GET %s : empty", url.c_str());
         return false;
     }
+
+    size_t len = (size_t)contentLen;
 
     uint8_t *pngImage = (uint8_t *)lv_malloc(len);
     LvFreeGuard pngGuard{pngImage};
@@ -63,12 +68,40 @@ bool URLService::load(const char *name, void *img)
         return false;
     }
 
-    size_t bytesRead = stream->readBytes(pngImage, len);
+    // read .png file in chunks to increase reliability (avoid readBytes())
+    size_t bytesRead = 0;
+    uint8_t idleSpins = 0;
+    const uint8_t maxIdleSpins = 3;
+    while (bytesRead < len) {
+        size_t available = stream->available();
+        if (available == 0) {
+            if (++idleSpins > maxIdleSpins) {
+                break;
+            }
+            delay(5);
+            continue;
+        }
+
+        idleSpins = 0;
+        size_t toRead = available;
+        size_t remaining = len - bytesRead;
+        if (toRead > remaining) {
+            toRead = remaining;
+        }
+
+        int got = stream->read(pngImage + bytesRead, toRead);
+        if (got <= 0) {
+            break;
+        }
+        bytesRead += (size_t)got;
+    }
+
     if (bytesRead != len) {
         ILOG_ERROR("http read error %s : %u != %u", url.c_str(), (unsigned int)bytesRead, (unsigned int)len);
         return false;
     }
-    ILOG_DEBUG("SUCCESS: GET %s (%u bytes)", url.c_str(), (unsigned int)bytesRead);
+
+    ILOG_DEBUG("SUCCESS(%d): GET %s (%u bytes)", (int)idleSpins, url.c_str(), (unsigned int)len);
 
     // save png tile to SD card
     if (saveCB && MapTileSettings::saveOK()) {


### PR DESCRIPTION
somehow required for the new arduino >= 3.x due to changes in mbed TLS / NetworkClientSecure

- Replace one-shot readBytes() with bounded polling loop
- Add idle-deadline tracking to tolerate partial TLS record arrivals
