### PR TITLE
fix: T-Deck (plus) touch TP INT behavior

### DIFF
--- a/include/graphics/LGFX/LGFX_T_DECK.h
+++ b/include/graphics/LGFX/LGFX_T_DECK.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #define LGFX_USE_V1
-#include <LovyanGFX.hpp>
 #include "util/ILog.h"
+#include <LovyanGFX.hpp>
 
 #ifndef SPI_FREQUENCY
 #define SPI_FREQUENCY 80000000
@@ -68,7 +68,8 @@ class LGFX_Touch : public lgfx::LGFX_Device
 };
 
 class GT911_TDECK : public lgfx::Touch_GT911
-{};
+{
+};
 class LGFX_TDECK : public LGFX_Touch
 
 #else
@@ -79,7 +80,8 @@ class GT911_TDECK : public lgfx::Touch_GT911
     static constexpr int GT911_I2C_ADDR_1 = 0x14;
     static constexpr int GT911_I2C_ADDR_2 = 0x5D;
 
-    bool init(void) override {
+    bool init(void) override
+    {
         bool result = lgfx::Touch_GT911::init();
         if (result) {
             checkAndConfigureGT911();
@@ -88,67 +90,43 @@ class GT911_TDECK : public lgfx::Touch_GT911
     }
 
   private:
-    bool transactionWriteReadWithAddrRetry(
-        const uint8_t *writeBuf,
-        size_t writeLen,
-        uint8_t *readBuf,
-        size_t readLen) {
-        auto txrx = lgfx::i2c::transactionWriteRead(
-            _cfg.i2c_port,
-            _cfg.i2c_addr,
-            writeBuf,
-            writeLen,
-            readBuf,
-            readLen,
-            _cfg.freq);
+    bool transactionWriteReadWithAddrRetry(const uint8_t *writeBuf, size_t writeLen, uint8_t *readBuf, size_t readLen)
+    {
+        auto txrx =
+            lgfx::i2c::transactionWriteRead(_cfg.i2c_port, _cfg.i2c_addr, writeBuf, writeLen, readBuf, readLen, _cfg.freq);
         if (txrx.has_value()) {
             return true;
         }
 
         int altAddr = (_cfg.i2c_addr == GT911_I2C_ADDR_1) ? GT911_I2C_ADDR_2 : GT911_I2C_ADDR_1;
-        txrx = lgfx::i2c::transactionWriteRead(
-            _cfg.i2c_port,
-            altAddr,
-            writeBuf,
-            writeLen,
-            readBuf,
-            readLen,
-            _cfg.freq);
+        txrx = lgfx::i2c::transactionWriteRead(_cfg.i2c_port, altAddr, writeBuf, writeLen, readBuf, readLen, _cfg.freq);
         if (txrx.has_value()) {
-            ILOG_DEBUG("GT911 diagnostic read succeeded using alternate I2C address 0x%02X (configured=0x%02X)",
-                       altAddr, _cfg.i2c_addr);
+            ILOG_DEBUG("GT911 diagnostic read succeeded using alternate I2C address 0x%02X (configured=0x%02X)", altAddr,
+                       _cfg.i2c_addr);
             return true;
         }
         return false;
     }
 
-    bool transactionWriteWithAddrRetry(const uint8_t *writeBuf, size_t writeLen) {
-        auto tx = lgfx::i2c::transactionWrite(
-            _cfg.i2c_port,
-            _cfg.i2c_addr,
-            writeBuf,
-            writeLen,
-            _cfg.freq);
+    bool transactionWriteWithAddrRetry(const uint8_t *writeBuf, size_t writeLen)
+    {
+        auto tx = lgfx::i2c::transactionWrite(_cfg.i2c_port, _cfg.i2c_addr, writeBuf, writeLen, _cfg.freq);
         if (tx.has_value()) {
             return true;
         }
 
         int altAddr = (_cfg.i2c_addr == GT911_I2C_ADDR_1) ? GT911_I2C_ADDR_2 : GT911_I2C_ADDR_1;
-        tx = lgfx::i2c::transactionWrite(
-            _cfg.i2c_port,
-            altAddr,
-            writeBuf,
-            writeLen,
-            _cfg.freq);
+        tx = lgfx::i2c::transactionWrite(_cfg.i2c_port, altAddr, writeBuf, writeLen, _cfg.freq);
         if (tx.has_value()) {
-            ILOG_DEBUG("GT911 diagnostic write succeeded using alternate I2C address 0x%02X (configured=0x%02X)",
-                       altAddr, _cfg.i2c_addr);
+            ILOG_DEBUG("GT911 diagnostic write succeeded using alternate I2C address 0x%02X (configured=0x%02X)", altAddr,
+                       _cfg.i2c_addr);
             return true;
         }
         return false;
     }
 
-    static uint8_t calcGT911Checksum(const uint8_t *buf, size_t len) {
+    static uint8_t calcGT911Checksum(const uint8_t *buf, size_t len)
+    {
         uint8_t checksum = 0;
         for (size_t i = 0; i < len; ++i) {
             checksum += buf[i];
@@ -156,17 +134,15 @@ class GT911_TDECK : public lgfx::Touch_GT911
         return static_cast<uint8_t>(~checksum + 1);
     }
 
-    bool writeGT911ConfigBlock(const uint8_t (&configBlock)[184]) {
+    bool writeGT911ConfigBlock(const uint8_t (&configBlock)[184])
+    {
         constexpr uint16_t configStart = 0x8047;
         constexpr size_t maxChunk = 30;
         size_t offset = 0;
         while (offset < sizeof(configBlock)) {
             const size_t chunk = (sizeof(configBlock) - offset > maxChunk) ? maxChunk : (sizeof(configBlock) - offset);
             const uint16_t reg = static_cast<uint16_t>(configStart + offset);
-            uint8_t packet[2 + maxChunk] = {
-                static_cast<uint8_t>((reg >> 8) & 0xFF),
-                static_cast<uint8_t>(reg & 0xFF)
-            };
+            uint8_t packet[2 + maxChunk] = {static_cast<uint8_t>((reg >> 8) & 0xFF), static_cast<uint8_t>(reg & 0xFF)};
             for (size_t i = 0; i < chunk; ++i) {
                 packet[2 + i] = configBlock[offset + i];
             }
@@ -176,11 +152,7 @@ class GT911_TDECK : public lgfx::Touch_GT911
             offset += chunk;
         }
 
-        uint8_t checksumWrite[3] = {
-            0x80,
-            0xFF,
-            calcGT911Checksum(configBlock, sizeof(configBlock))
-        };
+        uint8_t checksumWrite[3] = {0x80, 0xFF, calcGT911Checksum(configBlock, sizeof(configBlock))};
         if (!transactionWriteWithAddrRetry(checksumWrite, sizeof(checksumWrite))) {
             return false;
         }
@@ -189,25 +161,27 @@ class GT911_TDECK : public lgfx::Touch_GT911
         return transactionWriteWithAddrRetry(freshWrite, sizeof(freshWrite));
     }
 
-    bool readGT911ConfigBlock16(uint8_t (&configBlock)[16]) {
+    bool readGT911ConfigBlock16(uint8_t (&configBlock)[16])
+    {
         constexpr uint16_t configReg = 0x8047;
         uint8_t writeBuf[2] = {static_cast<uint8_t>((configReg >> 8) & 0xFF), static_cast<uint8_t>(configReg & 0xFF)};
         return transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), configBlock, sizeof(configBlock));
     }
 
-    void checkAndConfigureGT911(void) {
+    void checkAndConfigureGT911(void)
+    {
         // Log the runtime bus config that LovyanGFX selected during init.
-        ILOG_DEBUG("GT911 I2C config: port=%d addr=0x%02X sda=%d scl=%d freq=%u",
-                   _cfg.i2c_port, _cfg.i2c_addr, _cfg.pin_sda, _cfg.pin_scl, _cfg.freq);
+        ILOG_DEBUG("GT911 I2C config: port=%d addr=0x%02X sda=%d scl=%d freq=%u", _cfg.i2c_port, _cfg.i2c_addr, _cfg.pin_sda,
+                   _cfg.pin_scl, _cfg.freq);
 
         // READ PRODUCT INFO (HARDWARE ID & FIRMWARE)
         String productID = readGT911String(0x8140, 4);
-        uint16_t fwVersion   = readGT911U16(0x8144);
+        uint16_t fwVersion = readGT911U16(0x8144);
         uint16_t xResolution = readGT911U16(0x8146);
         uint16_t yResolution = readGT911U16(0x8148);
 
         ILOG_DEBUG("--- GT911 Chip Identification ---");
-        ILOG_DEBUG("Product ID:        %s",   productID.c_str());
+        ILOG_DEBUG("Product ID:        %s", productID.c_str());
         ILOG_DEBUG("Firmware Version:  0x%04X", fwVersion);
         ILOG_DEBUG("Screen Resolution: %u x %u", xResolution, yResolution);
 
@@ -218,8 +192,8 @@ class GT911_TDECK : public lgfx::Touch_GT911
             return;
         }
 
-        uint8_t configVersion = configBlockSmall[0]; // Register 0x8047
-        uint8_t moduleSwitch1 = configBlockSmall[6]; // Register 0x804D
+        uint8_t configVersion = configBlockSmall[0];   // Register 0x8047
+        uint8_t moduleSwitch1 = configBlockSmall[6];   // Register 0x804D
         uint8_t intTriggerMode = moduleSwitch1 & 0x03; // Lowest 2 bits
 
         static constexpr const char *intModeNames[] = {
@@ -267,14 +241,16 @@ class GT911_TDECK : public lgfx::Touch_GT911
         if (verifyMode == 0x02) {
             ILOG_INFO("GT911 TP_INT mode confirmed constant LOW after write (version=0x%02X)", verifyVersion);
         } else {
-            ILOG_ERROR("GT911 TP_INT verification failed: mode=0x%02X (expected 0x02), version=0x%02X",
-                       verifyMode, verifyVersion);
+            ILOG_ERROR("GT911 TP_INT verification failed: mode=0x%02X (expected 0x02), version=0x%02X", verifyMode,
+                       verifyVersion);
         }
     }
 
     // Helper function to read a string from GT911 registers
-    String readGT911String(uint16_t reg, int len) {
-        if (len <= 0) return "";
+    String readGT911String(uint16_t reg, int len)
+    {
+        if (len <= 0)
+            return "";
 
         String result = "";
         int offset = 0;
@@ -284,11 +260,13 @@ class GT911_TDECK : public lgfx::Touch_GT911
             uint8_t writeBuf[2] = {static_cast<uint8_t>((addr >> 8) & 0xFF), static_cast<uint8_t>(addr & 0xFF)};
             uint8_t readBuf[16] = {};
 
-            if (!transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), readBuf, chunk)) return "UNKNOWN";
+            if (!transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), readBuf, chunk))
+                return "UNKNOWN";
 
             for (size_t i = 0; i < chunk; ++i) {
                 char c = static_cast<char>(readBuf[i]);
-                if (c >= 32 && c <= 126) result += c; // Only printable characters
+                if (c >= 32 && c <= 126)
+                    result += c; // Only printable characters
             }
 
             offset += chunk;
@@ -297,10 +275,12 @@ class GT911_TDECK : public lgfx::Touch_GT911
     }
 
     // Helper function to read a 16-bit little-endian value
-    uint16_t readGT911U16(uint16_t reg) {
+    uint16_t readGT911U16(uint16_t reg)
+    {
         uint8_t writeBuf[2] = {static_cast<uint8_t>((reg >> 8) & 0xFF), static_cast<uint8_t>(reg & 0xFF)};
         uint8_t readBuf[2] = {};
-        if (!transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), readBuf, sizeof(readBuf))) return 0;
+        if (!transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), readBuf, sizeof(readBuf)))
+            return 0;
 
         return (static_cast<uint16_t>(readBuf[1]) << 8) | readBuf[0];
     }

--- a/include/graphics/LGFX/LGFX_T_DECK.h
+++ b/include/graphics/LGFX/LGFX_T_DECK.h
@@ -2,6 +2,7 @@
 
 #define LGFX_USE_V1
 #include <LovyanGFX.hpp>
+#include "util/ILog.h"
 
 #ifndef SPI_FREQUENCY
 #define SPI_FREQUENCY 80000000
@@ -66,15 +67,252 @@ class LGFX_Touch : public lgfx::LGFX_Device
     BBCapTouch bbct;
 };
 
+class GT911_TDECK : public lgfx::Touch_GT911
+{};
 class LGFX_TDECK : public LGFX_Touch
+
 #else
+// T-Deck specific configuration of GT911 touch driver
+class GT911_TDECK : public lgfx::Touch_GT911
+{
+  public:
+    static constexpr int GT911_I2C_ADDR_1 = 0x14;
+    static constexpr int GT911_I2C_ADDR_2 = 0x5D;
+
+    bool init(void) override {
+        bool result = lgfx::Touch_GT911::init();
+        if (result) {
+            checkAndConfigureGT911();
+        }
+        return result;
+    }
+
+  private:
+    bool transactionWriteReadWithAddrRetry(
+        const uint8_t *writeBuf,
+        size_t writeLen,
+        uint8_t *readBuf,
+        size_t readLen) {
+        auto txrx = lgfx::i2c::transactionWriteRead(
+            _cfg.i2c_port,
+            _cfg.i2c_addr,
+            writeBuf,
+            writeLen,
+            readBuf,
+            readLen,
+            _cfg.freq);
+        if (txrx.has_value()) {
+            return true;
+        }
+
+        int altAddr = (_cfg.i2c_addr == GT911_I2C_ADDR_1) ? GT911_I2C_ADDR_2 : GT911_I2C_ADDR_1;
+        txrx = lgfx::i2c::transactionWriteRead(
+            _cfg.i2c_port,
+            altAddr,
+            writeBuf,
+            writeLen,
+            readBuf,
+            readLen,
+            _cfg.freq);
+        if (txrx.has_value()) {
+            ILOG_DEBUG("GT911 diagnostic read succeeded using alternate I2C address 0x%02X (configured=0x%02X)",
+                       altAddr, _cfg.i2c_addr);
+            return true;
+        }
+        return false;
+    }
+
+    bool transactionWriteWithAddrRetry(const uint8_t *writeBuf, size_t writeLen) {
+        auto tx = lgfx::i2c::transactionWrite(
+            _cfg.i2c_port,
+            _cfg.i2c_addr,
+            writeBuf,
+            writeLen,
+            _cfg.freq);
+        if (tx.has_value()) {
+            return true;
+        }
+
+        int altAddr = (_cfg.i2c_addr == GT911_I2C_ADDR_1) ? GT911_I2C_ADDR_2 : GT911_I2C_ADDR_1;
+        tx = lgfx::i2c::transactionWrite(
+            _cfg.i2c_port,
+            altAddr,
+            writeBuf,
+            writeLen,
+            _cfg.freq);
+        if (tx.has_value()) {
+            ILOG_DEBUG("GT911 diagnostic write succeeded using alternate I2C address 0x%02X (configured=0x%02X)",
+                       altAddr, _cfg.i2c_addr);
+            return true;
+        }
+        return false;
+    }
+
+    static uint8_t calcGT911Checksum(const uint8_t *buf, size_t len) {
+        uint8_t checksum = 0;
+        for (size_t i = 0; i < len; ++i) {
+            checksum += buf[i];
+        }
+        return static_cast<uint8_t>(~checksum + 1);
+    }
+
+    bool writeGT911ConfigBlock(const uint8_t (&configBlock)[184]) {
+        constexpr uint16_t configStart = 0x8047;
+        constexpr size_t maxChunk = 30;
+        size_t offset = 0;
+        while (offset < sizeof(configBlock)) {
+            const size_t chunk = (sizeof(configBlock) - offset > maxChunk) ? maxChunk : (sizeof(configBlock) - offset);
+            const uint16_t reg = static_cast<uint16_t>(configStart + offset);
+            uint8_t packet[2 + maxChunk] = {
+                static_cast<uint8_t>((reg >> 8) & 0xFF),
+                static_cast<uint8_t>(reg & 0xFF)
+            };
+            for (size_t i = 0; i < chunk; ++i) {
+                packet[2 + i] = configBlock[offset + i];
+            }
+            if (!transactionWriteWithAddrRetry(packet, chunk + 2)) {
+                return false;
+            }
+            offset += chunk;
+        }
+
+        uint8_t checksumWrite[3] = {
+            0x80,
+            0xFF,
+            calcGT911Checksum(configBlock, sizeof(configBlock))
+        };
+        if (!transactionWriteWithAddrRetry(checksumWrite, sizeof(checksumWrite))) {
+            return false;
+        }
+
+        uint8_t freshWrite[3] = {0x81, 0x00, 0x01};
+        return transactionWriteWithAddrRetry(freshWrite, sizeof(freshWrite));
+    }
+
+    bool readGT911ConfigBlock16(uint8_t (&configBlock)[16]) {
+        constexpr uint16_t configReg = 0x8047;
+        uint8_t writeBuf[2] = {static_cast<uint8_t>((configReg >> 8) & 0xFF), static_cast<uint8_t>(configReg & 0xFF)};
+        return transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), configBlock, sizeof(configBlock));
+    }
+
+    void checkAndConfigureGT911(void) {
+        // Log the runtime bus config that LovyanGFX selected during init.
+        ILOG_DEBUG("GT911 I2C config: port=%d addr=0x%02X sda=%d scl=%d freq=%u",
+                   _cfg.i2c_port, _cfg.i2c_addr, _cfg.pin_sda, _cfg.pin_scl, _cfg.freq);
+
+        // READ PRODUCT INFO (HARDWARE ID & FIRMWARE)
+        String productID = readGT911String(0x8140, 4);
+        uint16_t fwVersion   = readGT911U16(0x8144);
+        uint16_t xResolution = readGT911U16(0x8146);
+        uint16_t yResolution = readGT911U16(0x8148);
+
+        ILOG_DEBUG("--- GT911 Chip Identification ---");
+        ILOG_DEBUG("Product ID:        %s",   productID.c_str());
+        ILOG_DEBUG("Firmware Version:  0x%04X", fwVersion);
+        ILOG_DEBUG("Screen Resolution: %u x %u", xResolution, yResolution);
+
+        // READ CONFIGURATION PARAMETERS (RAM WORKING MEMORY)
+        uint8_t configBlockSmall[16] = {0};
+        if (!readGT911ConfigBlock16(configBlockSmall)) {
+            ILOG_ERROR("Failed to read GT911 config block at 0x8047");
+            return;
+        }
+
+        uint8_t configVersion = configBlockSmall[0]; // Register 0x8047
+        uint8_t moduleSwitch1 = configBlockSmall[6]; // Register 0x804D
+        uint8_t intTriggerMode = moduleSwitch1 & 0x03; // Lowest 2 bits
+
+        static constexpr const char *intModeNames[] = {
+            "0x00 (Rising Edge Trigger)",
+            "0x01 (Falling Edge Trigger)",
+            "0x02 (CONSTANT LOW LEVEL ON TOUCH)",
+            "0x03 (Constant High Level on Touch)",
+        };
+
+        ILOG_DEBUG("--- GT911 Configuration Diagnostics ---");
+        ILOG_DEBUG("Config Version (Reg 0x8047): 0x%02X%s", configVersion,
+                   configVersion >= 0x5A ? "  <-- WARNING: High version number! Might block lower updates." : "  (Normal range)");
+        ILOG_DEBUG("Module_Switch1 (Reg 0x804D): 0x%02X", moduleSwitch1);
+        ILOG_INFO("Current TP INT Driver Mode:  %s", intModeNames[intTriggerMode]);
+
+        if (intTriggerMode == 0x02) {
+            return;
+        }
+
+        uint8_t configBlock[184] = {0};
+        uint8_t writeReg[2] = {0x80, 0x47};
+        if (!transactionWriteReadWithAddrRetry(writeReg, sizeof(writeReg), configBlock, sizeof(configBlock))) {
+            ILOG_ERROR("Failed to read full GT911 config block for update");
+            return;
+        }
+
+        configBlock[6] = static_cast<uint8_t>((configBlock[6] & 0xFC) | 0x02);
+        if (configBlock[0] < 0xFF) {
+            ++configBlock[0];
+        }
+
+        if (!writeGT911ConfigBlock(configBlock)) {
+            ILOG_ERROR("Failed to write updated GT911 config block");
+            return;
+        }
+
+        uint8_t verifyBlock[16] = {0};
+        if (!readGT911ConfigBlock16(verifyBlock)) {
+            ILOG_ERROR("GT911 config write done, but readback failed");
+            return;
+        }
+
+        uint8_t verifyVersion = verifyBlock[0];
+        uint8_t verifyMode = static_cast<uint8_t>(verifyBlock[6] & 0x03);
+        if (verifyMode == 0x02) {
+            ILOG_INFO("GT911 TP_INT mode confirmed constant LOW after write (version=0x%02X)", verifyVersion);
+        } else {
+            ILOG_ERROR("GT911 TP_INT verification failed: mode=0x%02X (expected 0x02), version=0x%02X",
+                       verifyMode, verifyVersion);
+        }
+    }
+
+    // Helper function to read a string from GT911 registers
+    String readGT911String(uint16_t reg, int len) {
+        if (len <= 0) return "";
+
+        String result = "";
+        int offset = 0;
+        while (offset < len) {
+            const size_t chunk = ((len - offset) < 16) ? (len - offset) : 16;
+            const uint16_t addr = reg + offset;
+            uint8_t writeBuf[2] = {static_cast<uint8_t>((addr >> 8) & 0xFF), static_cast<uint8_t>(addr & 0xFF)};
+            uint8_t readBuf[16] = {};
+
+            if (!transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), readBuf, chunk)) return "UNKNOWN";
+
+            for (size_t i = 0; i < chunk; ++i) {
+                char c = static_cast<char>(readBuf[i]);
+                if (c >= 32 && c <= 126) result += c; // Only printable characters
+            }
+
+            offset += chunk;
+        }
+        return result;
+    }
+
+    // Helper function to read a 16-bit little-endian value
+    uint16_t readGT911U16(uint16_t reg) {
+        uint8_t writeBuf[2] = {static_cast<uint8_t>((reg >> 8) & 0xFF), static_cast<uint8_t>(reg & 0xFF)};
+        uint8_t readBuf[2] = {};
+        if (!transactionWriteReadWithAddrRetry(writeBuf, sizeof(writeBuf), readBuf, sizeof(readBuf))) return 0;
+
+        return (static_cast<uint16_t>(readBuf[1]) << 8) | readBuf[0];
+    }
+};
+
 class LGFX_TDECK : public lgfx::LGFX_Device
 #endif
 {
     Panel_TDeck _panel_instance;
     lgfx::Bus_SPI _bus_instance;
     lgfx::Light_PWM _light_instance;
-    lgfx::Touch_GT911 _touch_instance;
+    GT911_TDECK _touch_instance;
     uint8_t brightness = 153;
 
   public:

--- a/include/graphics/driver/LGFXDriver.h
+++ b/include/graphics/driver/LGFXDriver.h
@@ -8,7 +8,7 @@
 #include "util/ILog.h"
 #include <functional>
 
-constexpr uint32_t defaultLongPressTime = 600; // ms until long press is detected (lvgl default is 400)
+constexpr uint32_t defaultLongPressTime = 700; // ms until long press is detected (lvgl default is 400)
 constexpr uint32_t defaultGestureLimit = 10;   // x/y diff pixel until a swipe gesture is detected (lvgl default is 50)
 
 constexpr uint32_t defaultScreenTimeout = 30 * 1000;
@@ -323,7 +323,7 @@ template <class LGFX> void LGFXDriver<LGFX>::init(DeviceGUI *gui)
 
     if (hasTouch()) {
         DisplayDriver::touch = lv_indev_create();
-        DisplayDriver::touch->gesture_limit = defaultGestureLimit;
+        lv_indev_set_scroll_limit(DisplayDriver::touch, defaultGestureLimit);
         lv_indev_set_type(DisplayDriver::touch, LV_INDEV_TYPE_POINTER);
         lv_indev_set_read_cb(DisplayDriver::touch, touchpad_read);
         lv_indev_set_display(DisplayDriver::touch, this->display);

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -4729,7 +4729,10 @@ void TFTView_320x240::addNode(uint32_t nodeNum, uint8_t ch, const char *userShor
     lv_obj_set_style_align(ui_Telemetry2Label, LV_ALIGN_TOP_RIGHT, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(ui_Telemetry2Label, LV_TEXT_ALIGN_RIGHT, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    // optimisation: hide all four extended labels by default; enable only when set
+    // optimisation: hide all 6ix extended labels by default; enable only when set
+    // lv_obj_add_flag(ui_lastHeardLabel, LV_OBJ_FLAG_HIDDEN); // lastHeard
+    lv_obj_add_flag(ui_BatteryLabel, LV_OBJ_FLAG_HIDDEN); // Autohide battery
+    lv_obj_add_flag(ui_SignalLabel, LV_OBJ_FLAG_HIDDEN);  // Autohide signal/hops
     lv_obj_add_flag(ui_PositionLabel, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(ui_Position2Label, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(ui_Telemetry1Label, LV_OBJ_FLAG_HIDDEN);
@@ -5043,6 +5046,7 @@ void TFTView_320x240::updateMetrics(uint32_t nodeNum, uint32_t bat_level, float 
             bat_level = std::min(bat_level, (uint32_t)100);
             sprintf(buf, "%d%% %0.2fV", bat_level, voltage);
             lv_label_set_text(it->second->LV_OBJ_IDX(node_bat_idx), buf);
+            lv_obj_remove_flag(it->second->LV_OBJ_IDX(node_bat_idx), LV_OBJ_FLAG_HIDDEN);
         }
     }
 }
@@ -5118,6 +5122,7 @@ void TFTView_320x240::updateSignalStrength(uint32_t nodeNum, int32_t rssi, float
             }
             lv_label_set_text(it->second->LV_OBJ_IDX(node_sig_idx), buf);
             it->second->LV_OBJ_IDX(node_sig_idx)->user_data = 0;
+            lv_obj_remove_flag(it->second->LV_OBJ_IDX(node_sig_idx), LV_OBJ_FLAG_HIDDEN);
         }
     }
 }
@@ -5131,6 +5136,7 @@ void TFTView_320x240::updateHopsAway(uint32_t nodeNum, uint8_t hopsAway)
             sprintf(buf, _("hops: %d"), (int)hopsAway);
             lv_label_set_text(it->second->LV_OBJ_IDX(node_sig_idx), buf);
             it->second->LV_OBJ_IDX(node_sig_idx)->user_data = (void *)(unsigned long)hopsAway;
+            lv_obj_remove_flag(it->second->LV_OBJ_IDX(node_sig_idx), LV_OBJ_FLAG_HIDDEN);
         }
     }
 }
@@ -6488,12 +6494,13 @@ void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t 
     lv_obj_set_align(msgLabel, LV_ALIGN_LEFT_MID);
     lv_label_set_text(msgLabel, msg);
     add_style_new_message_style(msgLabel);
+    lv_obj_add_flag(msgLabel, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+    lv_obj_add_event_cb(msgLabel, ui_event_chatNodeButton, LV_EVENT_CLICKED, (void *)nodeNum);
 
     if (state == MeshtasticView::eRunning) {
         lv_obj_scroll_to_view(hiddenPanel, LV_ANIM_ON);
         lv_obj_move_foreground(objects.message_input_area);
     }
-    lv_obj_add_event_cb(hiddenPanel, ui_event_chatNodeButton, LV_EVENT_CLICKED, (void *)nodeNum);
 }
 
 /**

--- a/source/input/I2CKeyboardScanner.cpp
+++ b/source/input/I2CKeyboardScanner.cpp
@@ -14,45 +14,100 @@ enum KeyboardAddresses {
 
 I2CKeyboardScanner::I2CKeyboardScanner(void) {}
 
+static bool probeTDeckKeyboardWithRegisterRead(uint8_t address)
+{
+    // Mirror firmware scanner behavior on 0x55:
+    // 0x00 => T-Deck keyboard, non-zero => BQ battery gauge.
+    Wire.beginTransmission(address);
+    Wire.write((uint8_t)0x04);
+    if (Wire.endTransmission() != 0) {
+        return false;
+    }
+
+    if (Wire.requestFrom((int)address, 1) != 1) {
+        return false;
+    }
+    if (!Wire.available()) {
+        return false;
+    }
+
+    return Wire.read() == 0;
+}
+
 I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
 {
     I2CKeyboardInputDriver *driver = nullptr;
 #ifndef ARCH_PORTDUINO
+    constexpr uint8_t kScanPasses = 2;
+    constexpr uint8_t kProbeRetries = 2;
+    constexpr uint16_t kProbeRetryDelayMs = 2;
+    constexpr uint16_t kInterPassDelayMs = 20;
+
     uint8_t i2cKeyboards[] = {SCAN_TDECK_KB_ADDR, SCAN_TCA8418_KB_ADDR, SCAN_CARDKB_ADDR, SCAN_BBQ10_KB_ADDR,
                               SCAN_MPR121_KB_ADDR};
     ILOG_DEBUG("I2CKeyboardScanner scanning...");
-    for (uint8_t i = 0; i < sizeof(i2cKeyboards); i++) {
-        uint8_t address = i2cKeyboards[i];
-        Wire.beginTransmission(address);
-        if (Wire.endTransmission() == 0) {
-            switch (address) {
-#if defined T_DECK
-            case SCAN_TDECK_KB_ADDR:
-                driver = new TDeckKeyboardInputDriver(address);
-                break;
+
+    // Reset I2C bus to clear any stuck state left by touch driver LovyanGFX operations
+    Wire.end();
+    delay(10);
+    Wire.begin(I2C_SDA, I2C_SCL, 100000);
+    delay(10);
+
+    for (uint8_t pass = 0; pass < kScanPasses && I2CKeyboardInputDriver::getI2CKeyboardList().empty(); ++pass) {
+        for (uint8_t i = 0; i < sizeof(i2cKeyboards); i++) {
+            uint8_t address = i2cKeyboards[i];
+            bool found = false;
+            for (uint8_t attempt = 0; attempt < kProbeRetries; ++attempt) {
+#if defined(T_DECK)
+                if (address == SCAN_TDECK_KB_ADDR) {
+                    found = probeTDeckKeyboardWithRegisterRead(address);
+                } else
 #endif
-            case SCAN_TCA8418_KB_ADDR:
-#if defined(T_LORA_PAGER)
-                driver = new TLoraPagerKeyboardInputDriver(address);
-#elif defined(T_DECK_PRO)
-                driver = new TDeckProKeyboardInputDriver(address);
-#else
-                // TODO: driver = new TCA8418KeyboardInputDriver(address);
-#endif
-                break;
-            case SCAN_CARDKB_ADDR:
-                driver = new CardKBInputDriver(address);
-                break;
-            case SCAN_BBQ10_KB_ADDR:
-                driver = new BBQ10KeyboardInputDriver(address);
-                break;
-            case SCAN_MPR121_KB_ADDR:
-                // TODO: resolve conflict with DRV2605
-                // driver = new MPR121KeyboardInputDriver(address);
-                break;
-            default:
-                break;
+                {
+                    Wire.beginTransmission(address);
+                    found = (Wire.endTransmission() == 0);
+                }
+
+                if (found) {
+                    break;
+                }
+                delay(kProbeRetryDelayMs);
             }
+
+            if (found) {
+                switch (address) {
+#if defined T_DECK
+                case SCAN_TDECK_KB_ADDR:
+                    driver = new TDeckKeyboardInputDriver(address);
+                    break;
+#endif
+                case SCAN_TCA8418_KB_ADDR:
+#if defined(T_LORA_PAGER)
+                    driver = new TLoraPagerKeyboardInputDriver(address);
+#elif defined(T_DECK_PRO)
+                    driver = new TDeckProKeyboardInputDriver(address);
+#else
+                    // TODO: driver = new TCA8418KeyboardInputDriver(address);
+#endif
+                    break;
+                case SCAN_CARDKB_ADDR:
+                    driver = new CardKBInputDriver(address);
+                    break;
+                case SCAN_BBQ10_KB_ADDR:
+                    driver = new BBQ10KeyboardInputDriver(address);
+                    break;
+                case SCAN_MPR121_KB_ADDR:
+                    // TODO: resolve conflict with DRV2605
+                    // driver = new MPR121KeyboardInputDriver(address);
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        if (I2CKeyboardInputDriver::getI2CKeyboardList().empty() && pass + 1 < kScanPasses) {
+            delay(kInterPassDelayMs);
         }
     }
     if (I2CKeyboardInputDriver::getI2CKeyboardList().empty()) {


### PR DESCRIPTION
This PR fixes the T-Deck Plus touch driver issue and re-introduces the more efficient GT911 touch driver.

During startup the following debug log information is printed: **CONSTANT LOW LEVEL ON TOUCH**
```
DEBUG | ??:??:?? 1 [DeviceUI] Display driver init...
DEBUG | ??:??:?? 1 [DeviceUI] LGFXDriver<LGFX>::init...
DEBUG | ??:??:?? 1 [DeviceUI] LGFX init...
DEBUG | ??:??:?? 2 [DeviceUI] GT911 I2C config: port=0 addr=0x14 sda=18 scl=8 freq=400000
DEBUG | ??:??:?? 2 [DeviceUI] --- GT911 Chip Identification ---
DEBUG | ??:??:?? 2 [DeviceUI] Product ID:        911
DEBUG | ??:??:?? 2 [DeviceUI] Firmware Version:  0x1060
DEBUG | ??:??:?? 2 [DeviceUI] Screen Resolution: 240 x 320
DEBUG | ??:??:?? 2 [DeviceUI] --- GT911 Configuration Diagnostics ---
DEBUG | ??:??:?? 2 [DeviceUI] Config Version (Reg 0x8047): 0x47  (Normal range)
DEBUG | ??:??:?? 2 [DeviceUI] Module_Switch1 (Reg 0x804D): 0xB6
INFO  | ??:??:?? 2 [DeviceUI] Current TP INT Driver Mode:  0x02 (CONSTANT LOW LEVEL ON TOUCH)
DEBUG | ??:??:?? 2 [DeviceUI] DisplayDriver init...
DEBUG | ??:??:?? 2 [DeviceUI] LV init...
DEBUG | ??:??:?? 2 [DeviceUI] LVGL display driver init...
DEBUG | ??:??:?? 2 [DeviceUI] LVGL: allocating 57600 bytes PSRAM for draw buffer (max free PSRAM: 3080180)
DEBUG | ??:??:?? 2 [DeviceUI] Input driver init...
DEBUG | ??:??:?? 2 [DeviceUI] I2CKeyboardScanner scanning...
INFO  | ??:??:?? 2 [DeviceUI] Registered I2C keyboard: T-Deck Keyboard at address 0x55
DEBUG | ??:??:?? 2 [DeviceUI] Panel id=0xffffffff (320x240): rst:-1, busy:-1, offX:0, offY:0 invert:0, RGB:0, rotation:0, offR:1, read:1, readP:8, readB:1, dlen:0, colordepth:16
DEBUG | ??:??:?? 2 [DeviceUI] Bus_SPI(1): clk:40, miso:38, mosi:41, dc:11, 3wire:0, dma:3
DEBUG | ??:??:?? 2 [DeviceUI] Touch int:16, rst:-1, rotation:0, (0/0)-(319/239) 
DEBUG | ??:??:?? 2 [DeviceUI] Touch I2C(0:0x14): SCL:8, SCA:18, freq:400000 
DEBUG | ??:??:?? 2 [DeviceUI] BL pin assigned
DEBUG | ??:??:?? 2 [DeviceUI] scanning log folder /messages
INFO  | ??:??:?? 2 [DeviceUI] LogRotate: found 0 log files using 0 bytes (0%).
INFO  | ??:??:?? 2 [DeviceUI] Logging to /messages/log_000001.log
DEBUG | ??:??:?? 2 [DeviceUI] DeviceScreen::init() done.
```

In case the display driver has a different configuration from the factory or OEM vendor then an attempt is made to reconfigure the GT911 driver and store the configuration persistently.

**Note:
After first start the T-Deck touch display may require calibration (settings -> screen calibration) to work accurately.**