### PR TITLE
fix: Keyboard scanning: reset I2C breaks some devices -> SCAN_I2C_BUS_RESET guard

### DIFF
--- a/include/input/I2CKeyboardInputDriver.h
+++ b/include/input/I2CKeyboardInputDriver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Arduino.h"
+#include "Wire.h"
 #include "input/InputDriver.h"
 #include <list>
 #include <memory>
@@ -79,9 +81,12 @@ class BBQ10KeyboardInputDriver : public I2CKeyboardInputDriver
 class CardKBInputDriver : public I2CKeyboardInputDriver
 {
   public:
-    CardKBInputDriver(uint8_t address);
+    CardKBInputDriver(uint8_t address, TwoWire &wire_ = Wire);
     void readKeyboard(uint8_t address, lv_indev_t *indev, lv_indev_data_t *data) override;
     virtual ~CardKBInputDriver(void) {}
+
+  private:
+    TwoWire &wire;
 };
 
 class MPR121KeyboardInputDriver : public I2CKeyboardInputDriver

--- a/source/input/I2CKeyboardInputDriver.cpp
+++ b/source/input/I2CKeyboardInputDriver.cpp
@@ -206,7 +206,7 @@ void BBQ10KeyboardInputDriver::readKeyboard(uint8_t address, lv_indev_t *indev, 
 
 // ---------- CardKBInputDriver Implementation ----------
 
-CardKBInputDriver::CardKBInputDriver(uint8_t address)
+CardKBInputDriver::CardKBInputDriver(uint8_t address, TwoWire &wire_) : wire(wire_)
 {
     registerI2CKeyboard(this, "Card Keyboard", address);
 }
@@ -214,9 +214,9 @@ CardKBInputDriver::CardKBInputDriver(uint8_t address)
 void CardKBInputDriver::readKeyboard(uint8_t address, lv_indev_t *indev, lv_indev_data_t *data)
 {
     char keyValue = 0;
-    Wire.requestFrom(address, 1);
-    if (Wire.available() > 0) {
-        keyValue = Wire.read();
+    wire.requestFrom(address, 1);
+    if (wire.available() > 0) {
+        keyValue = wire.read();
         // ignore empty reads and keycode 224 which causes internal issues
         if (keyValue != (char)0x00 && keyValue != (char)0xE0) {
             data->state = LV_INDEV_STATE_PRESSED;

--- a/source/input/I2CKeyboardScanner.cpp
+++ b/source/input/I2CKeyboardScanner.cpp
@@ -47,11 +47,13 @@ I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
                               SCAN_MPR121_KB_ADDR};
     ILOG_DEBUG("I2CKeyboardScanner scanning...");
 
+#ifdef SCAN_I2C_BUS_RESET
     // Reset I2C bus to clear any stuck state left by touch driver LovyanGFX operations
     Wire.end();
     delay(10);
     Wire.begin(I2C_SDA, I2C_SCL, 100000);
     delay(10);
+#endif
 
     for (uint8_t pass = 0; pass < kScanPasses && I2CKeyboardInputDriver::getI2CKeyboardList().empty(); ++pass) {
         for (uint8_t i = 0; i < sizeof(i2cKeyboards); i++) {

--- a/source/input/I2CKeyboardScanner.cpp
+++ b/source/input/I2CKeyboardScanner.cpp
@@ -116,6 +116,9 @@ I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
                 break;
             }
         }
+        if (driver != nullptr) {
+            break;
+        }
     }
 #endif
 

--- a/source/input/I2CKeyboardScanner.cpp
+++ b/source/input/I2CKeyboardScanner.cpp
@@ -9,109 +9,138 @@ enum KeyboardAddresses {
     SCAN_TCA8418_KB_ADDR = 0x34,
     SCAN_CARDKB_ADDR = 0x5F,
     SCAN_BBQ10_KB_ADDR = 0x1F,
-    SCAN_MPR121_KB_ADDR = 0x5A // also DRV2605
+    SCAN_MPR121_KB_ADDR = 0x5A, // also DRV2605
+    SCAN_TM9_KB_ADDR = 0x6C
 };
 
-I2CKeyboardScanner::I2CKeyboardScanner(void) {}
-
-static bool probeTDeckKeyboardWithRegisterRead(uint8_t address)
+namespace
 {
-    // Mirror firmware scanner behavior on 0x55:
-    // 0x00 => T-Deck keyboard, non-zero => BQ battery gauge.
-    Wire.beginTransmission(address);
-    Wire.write((uint8_t)0x04);
-    if (Wire.endTransmission() != 0) {
-        return false;
-    }
 
-    if (Wire.requestFrom((int)address, 1) != 1) {
+bool readRegisterByte(TwoWire &bus, uint8_t address, uint8_t reg, uint8_t &value)
+{
+    bus.beginTransmission(address);
+    bus.write(reg);
+    if (bus.endTransmission(false) != 0) {
         return false;
     }
-    if (!Wire.available()) {
+    if (bus.requestFrom((int)address, 1) != 1 || !bus.available()) {
         return false;
     }
-
-    return Wire.read() == 0;
+    value = bus.read();
+    return true;
 }
+
+#if defined T_DECK
+bool isBQ27220(TwoWire &bus, uint8_t address)
+{
+    uint8_t value = 0;
+    // Mirrors firmware scanner logic: non-zero at reg 0x04 indicates BQ27220.
+    return readRegisterByte(bus, address, 0x04, value) && value != 0;
+}
+#endif
+
+bool isTCA8418(TwoWire &bus, uint8_t address)
+{
+    uint8_t value = 0;
+    // Mirrors firmware scanner logic at address 0x34: reg 0x90 == 0 for TCA8418.
+    return readRegisterByte(bus, address, 0x90, value) && value == 0x00;
+}
+
+bool isDRV2605(TwoWire &bus, uint8_t address)
+{
+    uint8_t value = 0;
+    // Mirrors firmware scanner logic at address 0x5A: status reg 0x00 == 0xE0 for DRV2605.
+    return readRegisterByte(bus, address, 0x00, value) && value == 0xE0;
+}
+
+} // namespace
+
+I2CKeyboardScanner::I2CKeyboardScanner(void) {}
 
 I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
 {
     I2CKeyboardInputDriver *driver = nullptr;
 #ifndef ARCH_PORTDUINO
-    constexpr uint8_t kScanPasses = 2;
-    constexpr uint8_t kProbeRetries = 2;
-    constexpr uint16_t kProbeRetryDelayMs = 2;
-    constexpr uint16_t kInterPassDelayMs = 20;
+    uint8_t i2cKeyboards_bus0[] = {SCAN_TCA8418_KB_ADDR, SCAN_CARDKB_ADDR, SCAN_BBQ10_KB_ADDR, SCAN_MPR121_KB_ADDR};
+#if WIRE_INTERFACES_COUNT >= 2
+    uint8_t i2cKeyboards_bus1[] = {SCAN_CARDKB_ADDR, SCAN_TM9_KB_ADDR};
+#endif
 
-    uint8_t i2cKeyboards[] = {SCAN_TDECK_KB_ADDR, SCAN_TCA8418_KB_ADDR, SCAN_CARDKB_ADDR, SCAN_BBQ10_KB_ADDR,
-                              SCAN_MPR121_KB_ADDR};
-    ILOG_DEBUG("I2CKeyboardScanner scanning...");
-
-#ifdef SCAN_I2C_BUS_RESET
     // Reset I2C bus to clear any stuck state left by touch driver LovyanGFX operations
+#ifdef SCAN_I2C_BUS_RESET
+    ILOG_DEBUG("Resetting I2C bus ...");
     Wire.end();
     delay(10);
     Wire.begin(I2C_SDA, I2C_SCL, 100000);
     delay(10);
 #endif
 
-    for (uint8_t pass = 0; pass < kScanPasses && I2CKeyboardInputDriver::getI2CKeyboardList().empty(); ++pass) {
-        for (uint8_t i = 0; i < sizeof(i2cKeyboards); i++) {
-            uint8_t address = i2cKeyboards[i];
-            bool found = false;
-            for (uint8_t attempt = 0; attempt < kProbeRetries; ++attempt) {
+    // skip scanning for known keyboard devices
 #if defined(T_DECK)
-                if (address == SCAN_TDECK_KB_ADDR) {
-                    found = probeTDeckKeyboardWithRegisterRead(address);
-                } else
-#endif
-                {
-                    Wire.beginTransmission(address);
-                    found = (Wire.endTransmission() == 0);
-                }
-
-                if (found) {
-                    break;
-                }
-                delay(kProbeRetryDelayMs);
-            }
-
-            if (found) {
-                switch (address) {
-#if defined T_DECK
-                case SCAN_TDECK_KB_ADDR:
-                    driver = new TDeckKeyboardInputDriver(address);
-                    break;
-#endif
-                case SCAN_TCA8418_KB_ADDR:
-#if defined(T_LORA_PAGER)
-                    driver = new TLoraPagerKeyboardInputDriver(address);
+    driver = new TDeckKeyboardInputDriver(SCAN_TDECK_KB_ADDR);
+#elif defined(T_LORA_PAGER)
+    driver = new TLoraPagerKeyboardInputDriver(SCAN_TCA8418_KB_ADDR);
 #elif defined(T_DECK_PRO)
-                    driver = new TDeckProKeyboardInputDriver(address);
+    driver = new TDeckProKeyboardInputDriver(SCAN_TCA8418_KB_ADDR);
+#elif defined(ELECROW_ThinkNode_M9)
+    driver = new TM9KeyboardInputDriver(SCAN_TM9_KB_ADDR);
 #else
-                    // TODO: driver = new TCA8418KeyboardInputDriver(address);
-#endif
-                    break;
-                case SCAN_CARDKB_ADDR:
-                    driver = new CardKBInputDriver(address);
-                    break;
-                case SCAN_BBQ10_KB_ADDR:
-                    driver = new BBQ10KeyboardInputDriver(address);
-                    break;
-                case SCAN_MPR121_KB_ADDR:
-                    // TODO: resolve conflict with DRV2605
-                    // driver = new MPR121KeyboardInputDriver(address);
-                    break;
-                default:
-                    break;
+    ILOG_DEBUG("I2CKeyboardScanner scanning bus 0 ...");
+    for (uint8_t i = 0; i < sizeof(i2cKeyboards_bus0); i++) {
+        uint8_t address = i2cKeyboards_bus0[i];
+        ILOG_DEBUG("trying address 0x%02X...", address);
+        Wire.beginTransmission(address);
+        if (Wire.endTransmission() == 0) {
+            switch (address) {
+            case SCAN_TCA8418_KB_ADDR:
+                if (isTCA8418(Wire, address)) {
+                    driver = new TCA8418KeyboardInputDriver(address);
+                } else {
+                    ILOG_DEBUG("Address 0x%02X is not TCA8418 signature, skipping keyboard attach", address);
                 }
+                break;
+            case SCAN_CARDKB_ADDR:
+                driver = new CardKBInputDriver(address);
+                break;
+            case SCAN_BBQ10_KB_ADDR:
+                driver = new BBQ10KeyboardInputDriver(address);
+                break;
+            case SCAN_MPR121_KB_ADDR:
+                if (isDRV2605(Wire, address)) {
+                    ILOG_DEBUG("Address 0x%02X appears to be DRV2605, skipping MPR121 keyboard", address);
+                } else {
+                    driver = new MPR121KeyboardInputDriver(address);
+                }
+                break;
+            default:
+                break;
             }
-        }
-
-        if (I2CKeyboardInputDriver::getI2CKeyboardList().empty() && pass + 1 < kScanPasses) {
-            delay(kInterPassDelayMs);
         }
     }
+#endif
+
+#if WIRE_INTERFACES_COUNT >= 2
+    ILOG_DEBUG("I2CKeyboardScanner scanning bus 1 ...");
+    for (uint8_t i = 0; i < sizeof(i2cKeyboards_bus1); i++) {
+        uint8_t address = i2cKeyboards_bus1[i];
+        Wire1.beginTransmission(address);
+        if (Wire1.endTransmission() == 0) {
+            switch (address) {
+            case SCAN_CARDKB_ADDR:
+                driver = new CardKBInputDriver(address, Wire1);
+                break;
+            case SCAN_TM9_KB_ADDR:
+#ifdef HAS_STC8H_KB
+                driver = new STC8HKeyboardInputDriver(address, Wire1);
+#endif
+                break;
+            default:
+                break;
+            }
+        }
+    }
+#endif
+
     if (I2CKeyboardInputDriver::getI2CKeyboardList().empty()) {
         ILOG_DEBUG("No I2C keyboards found");
     }

--- a/source/input/I2CKeyboardScanner.cpp
+++ b/source/input/I2CKeyboardScanner.cpp
@@ -30,15 +30,6 @@ bool readRegisterByte(TwoWire &bus, uint8_t address, uint8_t reg, uint8_t &value
     return true;
 }
 
-#if defined T_DECK
-bool isBQ27220(TwoWire &bus, uint8_t address)
-{
-    uint8_t value = 0;
-    // Mirrors firmware scanner logic: non-zero at reg 0x04 indicates BQ27220.
-    return readRegisterByte(bus, address, 0x04, value) && value != 0;
-}
-#endif
-
 bool isTCA8418(TwoWire &bus, uint8_t address)
 {
     uint8_t value = 0;
@@ -122,7 +113,7 @@ I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
     }
 #endif
 
-`#if` WIRE_INTERFACES_COUNT >= 2
+#if WIRE_INTERFACES_COUNT >= 2
     if (driver == nullptr) {
         ILOG_DEBUG("I2CKeyboardScanner scanning bus 1 ...");
         for (uint8_t i = 0; i < sizeof(i2cKeyboards_bus1); i++) {
@@ -134,9 +125,9 @@ I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
                     driver = new CardKBInputDriver(address, Wire1);
                     break;
                 case SCAN_TM9_KB_ADDR:
-`#ifdef` HAS_STC8H_KB
+#ifdef HAS_STC8H_KB
                     driver = new STC8HKeyboardInputDriver(address, Wire1);
-`#endif`
+#endif
                     break;
                 default:
                     break;
@@ -147,7 +138,7 @@ I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
             }
         }
     }
-`#endif`
+#endif
 
     if (I2CKeyboardInputDriver::getI2CKeyboardList().empty()) {
         ILOG_DEBUG("No I2C keyboards found");

--- a/source/input/I2CKeyboardScanner.cpp
+++ b/source/input/I2CKeyboardScanner.cpp
@@ -122,27 +122,32 @@ I2CKeyboardInputDriver *I2CKeyboardScanner::scan(void)
     }
 #endif
 
-#if WIRE_INTERFACES_COUNT >= 2
-    ILOG_DEBUG("I2CKeyboardScanner scanning bus 1 ...");
-    for (uint8_t i = 0; i < sizeof(i2cKeyboards_bus1); i++) {
-        uint8_t address = i2cKeyboards_bus1[i];
-        Wire1.beginTransmission(address);
-        if (Wire1.endTransmission() == 0) {
-            switch (address) {
-            case SCAN_CARDKB_ADDR:
-                driver = new CardKBInputDriver(address, Wire1);
-                break;
-            case SCAN_TM9_KB_ADDR:
-#ifdef HAS_STC8H_KB
-                driver = new STC8HKeyboardInputDriver(address, Wire1);
-#endif
-                break;
-            default:
+`#if` WIRE_INTERFACES_COUNT >= 2
+    if (driver == nullptr) {
+        ILOG_DEBUG("I2CKeyboardScanner scanning bus 1 ...");
+        for (uint8_t i = 0; i < sizeof(i2cKeyboards_bus1); i++) {
+            uint8_t address = i2cKeyboards_bus1[i];
+            Wire1.beginTransmission(address);
+            if (Wire1.endTransmission() == 0) {
+                switch (address) {
+                case SCAN_CARDKB_ADDR:
+                    driver = new CardKBInputDriver(address, Wire1);
+                    break;
+                case SCAN_TM9_KB_ADDR:
+`#ifdef` HAS_STC8H_KB
+                    driver = new STC8HKeyboardInputDriver(address, Wire1);
+`#endif`
+                    break;
+                default:
+                    break;
+                }
+            }
+            if (driver != nullptr) {
                 break;
             }
         }
     }
-#endif
+`#endif`
 
     if (I2CKeyboardInputDriver::getI2CKeyboardList().empty()) {
         ILOG_DEBUG("No I2C keyboards found");


### PR DESCRIPTION
reset I2C bus is now guarded by SCAN_I2C_BUS_RESET

Some devices needed to reset the bus before scanning (e.g. T-Deck).

For well known devices with keyboard the scan is omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster automatic detection of keyboard peripherals using a single-pass, fixed-address I2C scan with controller identity verification.
  * Enhanced support for multi-bus hardware by scanning an additional I2C bus (when available) and expanding recognized keyboard addresses.
  * On supported keyboard-equipped devices, detection now targets the expected controller address directly for quicker startup.
* **Bug Fixes**
  * Reduced incorrect peripheral matches by validating devices via register-based signature checks.
  * Improved scan stability by optionally resetting the I2C bus during detection and ensuring keyboard reads use the correct I2C bus instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->