### PR TITLE
fix: guard modem preset frequency when region unset

### DIFF
--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -1741,7 +1741,8 @@ void TFTView_320x240::ui_event_region_button(lv_event_t *e)
 void TFTView_320x240::ui_event_preset_button(lv_event_t *e)
 {
     lv_event_code_t event_code = lv_event_get_code(e);
-    if (event_code == LV_EVENT_CLICKED && THIS->activeSettings == eNone && THIS->db.config.lora.use_preset) {
+    if (event_code == LV_EVENT_CLICKED && THIS->activeSettings == eNone && THIS->db.config.lora.use_preset &&
+        THIS->db.config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_UNSET) {
         THIS->activeSettings = eModemPreset;
         lv_dropdown_set_selected(objects.settings_modem_preset_dropdown, THIS->preset2val(THIS->db.config.lora.modem_preset));
 
@@ -6013,8 +6014,13 @@ void TFTView_320x240::updateLoRaConfig(const meshtastic_Config_LoRaConfig &cfg)
         lv_label_set_text(objects.basic_settings_modem_preset_label, buf2);
 
         uint32_t numChannels = LoRaPresets::getNumChannels(cfg.region, cfg.modem_preset);
-        lv_slider_set_range(objects.frequency_slot_slider, 1, numChannels);
-        lv_slider_set_value(objects.frequency_slot_slider, db.config.lora.channel_num, LV_ANIM_OFF);
+        if (numChannels) {
+            lv_slider_set_range(objects.frequency_slot_slider, 1, numChannels);
+            lv_slider_set_value(objects.frequency_slot_slider, db.config.lora.channel_num, LV_ANIM_OFF);
+        } else {
+            lv_slider_set_range(objects.frequency_slot_slider, 0, 0);
+            lv_slider_set_value(objects.frequency_slot_slider, 0, LV_ANIM_OFF);
+        }
     } else {
         lv_label_set_text(objects.basic_settings_modem_preset_label, _("Modem Preset: custom"));
     }
@@ -6042,6 +6048,7 @@ void TFTView_320x240::showLoRaFrequency(const meshtastic_Config_LoRaConfig &cfg)
     char loraFreq[48];
     if (!cfg.region) {
         strcpy(loraFreq, _("region unset"));
+        lv_obj_add_state(objects.basic_settings_modem_preset_button, LV_STATE_DISABLED);
     } else if (cfg.use_preset) {
         float frequency = LoRaPresets::getRadioFreq(cfg.region, cfg.modem_preset, cfg.channel_num) + cfg.frequency_offset;
         sprintf(loraFreq, "LoRa %g MHz\n[%s kHz]", frequency, LoRaPresets::getBandwidthString(cfg.modem_preset));

--- a/source/graphics/common/LoRaPresets.cpp
+++ b/source/graphics/common/LoRaPresets.cpp
@@ -80,6 +80,10 @@ uint32_t LoRaPresets::getNumChannels(meshtastic_Config_LoRaConfig_RegionCode reg
 float LoRaPresets::getRadioFreq(meshtastic_Config_LoRaConfig_RegionCode region, meshtastic_Config_LoRaConfig_ModemPreset preset,
                                 uint32_t channel)
 {
+    if (region == meshtastic_Config_LoRaConfig_RegionCode_UNSET || channel == 0) {
+        return 0.0f;
+    }
+
     return (regionInfo[region].freqStart + modemPreset[preset].bandwidth_MHz / 2) +
            (channel - 1) * modemPreset[preset].bandwidth_MHz;
 }

--- a/tests/test_LoRaPresets.cpp
+++ b/tests/test_LoRaPresets.cpp
@@ -1,0 +1,12 @@
+#include "graphics/common/LoRaPresets.h"
+#include <doctest/doctest.h>
+
+TEST_CASE("LoRaPresets::getRadioFreq returns no frequency without a valid region and slot")
+{
+    CHECK(LoRaPresets::getRadioFreq(meshtastic_Config_LoRaConfig_RegionCode_UNSET,
+                                    meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST, 0) == doctest::Approx(0.0f));
+    CHECK(LoRaPresets::getRadioFreq(meshtastic_Config_LoRaConfig_RegionCode_US,
+                                    meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST, 0) == doctest::Approx(0.0f));
+    CHECK(LoRaPresets::getRadioFreq(meshtastic_Config_LoRaConfig_RegionCode_US,
+                                    meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST, 1) == doctest::Approx(902.125f));
+}


### PR DESCRIPTION
## Summary
- Prevent unset-region LoRa settings from rendering a bogus modem-preset frequency.
- Keep the modem preset settings button disabled until a valid region is selected.
- Treat unset region or slot `0` as no valid radio frequency in `LoRaPresets::getRadioFreq()`.
- Add a doctest regression for the unset-region/slot-zero frequency path.

## Proof
The bug was observed on a T-Deck with region unset. Opening the modem preset picker displayed `FrequencySlot: 0 (1.07374e+09 MHz)`:

![T-Deck showing unset-region modem preset frequency bug](https://raw.githubusercontent.com/RCGV1/device-ui/0f35f5329300ede47bd32f4cb596ba877d69ce49/proof/unset-region-modem-preset.jpg)

## Root Cause
`LoRaPresets::getNumChannels()` already returns `0` for `RegionCode_UNSET`, but `getRadioFreq()` still performed unsigned slot math. With `channel == 0`, `(channel - 1)` underflowed and produced a huge MHz value.

## Validation
- `git diff --check`
- Focused regression harness against `LoRaPresets.cpp`:
  - before fix: `unset=1.07374e+09 zeroSlot=1.07374e+09 valid=902.125`, exit `1`
  - after fix: `unset=0 zeroSlot=0 valid=902.125`, exit `0`

Note: local full CMake/doctest build on macOS is blocked before test execution by unrelated fetched Portduino/protobuf setup issues; the repo regression test is included for CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LoRa modem preset controls now only appear when a valid region is selected, preventing unavailable settings from being shown.
  * Frequency selection is now properly disabled when no valid LoRa channels are available, reducing confusion in the settings screen.
  * Invalid LoRa region or channel selections now no longer produce a frequency value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->