### PR TITLE
fix: send message on main Return key in MUI composer (X11/native-tft)

### DIFF
--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -1678,6 +1678,15 @@ void TFTView_320x240::ui_event_Keyboard(lv_event_t *e)
 void TFTView_320x240::ui_event_message_ready(lv_event_t *e)
 {
     lv_event_code_t event_code = lv_event_get_code(e);
+    if (event_code == LV_EVENT_KEY) {
+        // LVGL's X11 driver maps only keypad enter to LV_KEY_ENTER; the main Return
+        // key arrives as raw '\r' and is silently dropped by the one-line textarea.
+        // Treat it as ready-to-send so a physical Enter submits the message.
+        uint32_t *key = (uint32_t *)lv_event_get_param(e);
+        if (!key || *key != '\r')
+            return;
+        event_code = LV_EVENT_READY;
+    }
     if (event_code == LV_EVENT_READY) {
         char *txt = (char *)lv_textarea_get_text(objects.message_input_area);
         uint32_t len = strlen(txt);


### PR DESCRIPTION
Fixes #344

On the `native-tft` (X11) build, the main Return key arrives as a raw `'\r'` because LVGL's X11 driver only maps `XK_KP_Enter` to `LV_KEY_ENTER`. The one-line composer textarea silently discards `'\r'`, so `LV_EVENT_READY` never fires and the message is never sent — only the on-screen keyboard checkmark (or keypad Enter) worked.

## Change

`ui_event_message_ready` is already registered with `LV_EVENT_ALL`, so it receives the `LV_EVENT_KEY` event after the textarea class handler drops the char. This PR handles `LV_EVENT_KEY == '\r'` there and routes it into the existing `LV_EVENT_READY` send logic.

- No double-send for keypad Enter / libinput Enter: those arrive as `LV_KEY_ENTER` (`'\n'`), which already triggers a nested `LV_EVENT_READY` from the textarea class handler, and `'\n' != '\r'` so this handler ignores them.
- The space+return `CR_REPLACEMENT` newline trick keeps working, now also with the physical Return key.
- 9 lines, confined to `TFTView_320x240.cpp`.

See #344 for the full diagnosis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Physical Enter key presses now correctly submit one-line messages from the message input.
  * Virtual keyboard carriage return key events are treated the same as the on-screen “ready” action, improving consistency; other key events are ignored to prevent unintended sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->