### PR TITLE
fix: use malloc() for LVGL pool on CONFIG_SPIRAM_USE_MALLOC builds

### DIFF
--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -69,8 +69,12 @@
     /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
     #if LV_MEM_ADR == 0
         #if defined BOARD_HAS_PSRAM
-          #define LV_MEM_POOL_INCLUDE     <esp_heap_caps.h>
-          #define LV_MEM_POOL_ALLOC(size) heap_caps_aligned_alloc(32, size, MALLOC_CAP_SPIRAM)
+          /* CONFIG_SPIRAM_USE_MALLOC=y integrates PSRAM into the regular heap so
+           * MALLOC_CAP_SPIRAM capability is not set; heap_caps_aligned_alloc with
+           * that cap returns NULL. Use plain malloc() — large allocations route to
+           * PSRAM automatically. */
+          #define LV_MEM_POOL_INCLUDE     <stdlib.h>
+          #define LV_MEM_POOL_ALLOC(size) malloc(size)
         #else
           #undef LV_MEM_POOL_INCLUDE
           #undef LV_MEM_POOL_ALLOC


### PR DESCRIPTION
With CONFIG_SPIRAM_USE_MALLOC=y the ESP-IDF integrates PSRAM into the regular heap via the standard allocator. In this mode the PSRAM regions do NOT carry the MALLOC_CAP_SPIRAM capability, so:

  heap_caps_aligned_alloc(32, size, MALLOC_CAP_SPIRAM)

returns NULL, causing LVGL's TLSF pool init to crash (null deref at offset 0x0b into the pool).

Using plain malloc() is correct: the ESP-IDF CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL threshold ensures large allocations (the pool is typically 1+ MB) go to PSRAM automatically without needing the cap.

Affects any ESP32-S3 variant built with CONFIG_SPIRAM_USE_MALLOC=y (the default for arduino-esp32 3.x / IDF 5.x boards with PSRAM).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PSRAM memory allocation compatibility by using the standard memory allocator in supported configurations.
  * Helps ensure more reliable memory allocation for devices using PSRAM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->