### PR TITLE
fix: Use map tile HTTP requests to skip TLS handshake

### DIFF
--- a/source/graphics/map/TileProvider.cpp
+++ b/source/graphics/map/TileProvider.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 std::vector<std::tuple<std::string, std::string>> TileProvider::urlTemplates = {
-    {"URL: Google Maps", "https://mt0.google.com/vt?lyrs=m&x={x}&s=&y={y}&z={z}"}};
+    {"URL: Google Maps", "http://mt0.google.com/vt?lyrs=m&x={x}&s=&y={y}&z={z}"}};
 
 std::string TileProvider::url(const char *filename)
 {

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -20,8 +20,6 @@ URLService::~URLService() {}
 
 bool URLService::load(const char *name, void *img)
 {
-    HTTPClient http;
-
     if (WiFi.status() != WL_CONNECTED) {
         ILOG_DEBUG("URLService::load skipped (WiFi not connected)");
         return false;
@@ -42,7 +40,9 @@ bool URLService::load(const char *name, void *img)
     NetworkClientSecure secureClient;
     secureClient.setInsecure();
 
+    HTTPClient http;
     http.setReuse(false);
+
     if (!http.begin(secureClient, url.c_str())) {
         ILOG_ERROR("ERROR begin %s", url.c_str());
         return false;

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -8,6 +8,7 @@
 #ifdef ARDUINO_ARCH_ESP32
 
 #include "HTTPClient.h" // not available on Linux/Portduino
+#include "NetworkClientSecure.h"
 #include "WiFi.h"
 
 URLService::URLService(Callback cb) : ITileService("HTTP:"), saveCB(cb)
@@ -38,8 +39,11 @@ bool URLService::load(const char *name, void *img)
         return false;
     }
 
+    NetworkClientSecure secureClient;
+    secureClient.setInsecure();
+
     http.setReuse(false);
-    if (!http.begin(url.c_str())) {
+    if (!http.begin(secureClient, url.c_str())) {
         ILOG_ERROR("ERROR begin %s", url.c_str());
         return false;
     }

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -37,13 +37,20 @@ bool URLService::load(const char *name, void *img)
         return false;
     }
 
-    NetworkClientSecure secureClient;
-    secureClient.setInsecure();
+    NetworkClient networkClient;
+    NetworkClient *client = &networkClient;
+    std::unique_ptr<NetworkClientSecure> secureHolder;
+
+    const bool isSecure = (url.rfind("https://", 0) == 0);
+    if (isSecure) {
+        secureHolder = std::make_unique<NetworkClientSecure>();
+        client = static_cast<NetworkClient *>(secureHolder.get());
+    }
 
     HTTPClient http;
     http.setReuse(false);
 
-    if (!http.begin(secureClient, url.c_str())) {
+    if (!http.begin(*client, url.c_str())) {
         ILOG_ERROR("ERROR begin %s", url.c_str());
         return false;
     }


### PR DESCRIPTION
fixes #360 where TLS handshake runs out of memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map tile downloads on ESP32 devices by selecting the appropriate connection type for secure and standard web addresses.
  * Updated the default map tile address to improve compatibility across supported connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->