### PR TITLE
fix: Refactor URLService::load() to improve HTTP handling

### DIFF
--- a/generated/ui_320x240/screens.c
+++ b/generated/ui_320x240/screens.c
@@ -1670,6 +1670,20 @@ void create_screen_main_screen() {
                     lv_label_set_text_static(obj, "");
                 }
                 {
+                    // mapAttributionLabel
+                    lv_obj_t *obj = lv_label_create(parent_obj);
+                    objects.map_attribution_label = obj;
+                    lv_obj_set_pos(obj, 0, -1);
+                    lv_obj_set_size(obj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+                    lv_label_set_long_mode(obj, LV_LABEL_LONG_CLIP);
+                    lv_obj_remove_flag(obj, LV_OBJ_FLAG_CLICK_FOCUSABLE|LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_PRESS_LOCK|LV_OBJ_FLAG_SCROLLABLE|LV_OBJ_FLAG_SCROLL_CHAIN_HOR|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_WITH_ARROW|LV_OBJ_FLAG_SNAPPABLE);
+                    lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_obj_set_style_text_font(obj, &ui_font_montserrat_12, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_obj_set_style_text_color(obj, lv_color_hex(0x212121), LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_obj_set_style_text_opa(obj, 200, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_label_set_text_static(obj, "");
+                }
+                {
                     // googleLogoImage
                     lv_obj_t *obj = lv_image_create(parent_obj);
                     objects.google_logo_image = obj;
@@ -3228,7 +3242,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 239);
+                    create_user_widget_ok_cancel_widget(obj, 240);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3540,7 +3554,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 260);
+                    create_user_widget_ok_cancel_widget(obj, 261);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3586,7 +3600,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 266);
+                    create_user_widget_ok_cancel_widget(obj, 267);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3665,7 +3679,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 274);
+                    create_user_widget_ok_cancel_widget(obj, 275);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3712,7 +3726,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 280);
+                    create_user_widget_ok_cancel_widget(obj, 281);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3823,7 +3837,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 289);
+                    create_user_widget_ok_cancel_widget(obj, 290);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3887,7 +3901,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 296);
+                    create_user_widget_ok_cancel_widget(obj, 297);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3933,7 +3947,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 302);
+                    create_user_widget_ok_cancel_widget(obj, 303);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3998,7 +4012,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 309);
+                    create_user_widget_ok_cancel_widget(obj, 310);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4104,7 +4118,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 317);
+                    create_user_widget_ok_cancel_widget(obj, 318);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -4191,7 +4205,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 325);
+                    create_user_widget_ok_cancel_widget(obj, 326);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4267,7 +4281,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 332);
+                    create_user_widget_ok_cancel_widget(obj, 333);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4313,7 +4327,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 338);
+                    create_user_widget_ok_cancel_widget(obj, 339);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4390,7 +4404,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 345);
+                    create_user_widget_ok_cancel_widget(obj, 346);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4456,7 +4470,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 353);
+                    create_user_widget_ok_cancel_widget(obj, 354);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4501,7 +4515,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 359);
+                    create_user_widget_ok_cancel_widget(obj, 360);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4646,7 +4660,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 372);
+                    create_user_widget_ok_cancel_widget(obj, 373);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -6322,7 +6336,7 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            create_user_widget_ok_cancel_widget(obj, 478);
+                            create_user_widget_ok_cancel_widget(obj, 479);
                             lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
@@ -6384,24 +6398,24 @@ void create_screen_main_screen() {
 }
 
 void tick_screen_main_screen() {
-    tick_user_widget_ok_cancel_widget(239);
-    tick_user_widget_ok_cancel_widget(260);
-    tick_user_widget_ok_cancel_widget(266);
-    tick_user_widget_ok_cancel_widget(274);
-    tick_user_widget_ok_cancel_widget(280);
-    tick_user_widget_ok_cancel_widget(289);
-    tick_user_widget_ok_cancel_widget(296);
-    tick_user_widget_ok_cancel_widget(302);
-    tick_user_widget_ok_cancel_widget(309);
-    tick_user_widget_ok_cancel_widget(317);
-    tick_user_widget_ok_cancel_widget(325);
-    tick_user_widget_ok_cancel_widget(332);
-    tick_user_widget_ok_cancel_widget(338);
-    tick_user_widget_ok_cancel_widget(345);
-    tick_user_widget_ok_cancel_widget(353);
-    tick_user_widget_ok_cancel_widget(359);
-    tick_user_widget_ok_cancel_widget(372);
-    tick_user_widget_ok_cancel_widget(478);
+    tick_user_widget_ok_cancel_widget(240);
+    tick_user_widget_ok_cancel_widget(261);
+    tick_user_widget_ok_cancel_widget(267);
+    tick_user_widget_ok_cancel_widget(275);
+    tick_user_widget_ok_cancel_widget(281);
+    tick_user_widget_ok_cancel_widget(290);
+    tick_user_widget_ok_cancel_widget(297);
+    tick_user_widget_ok_cancel_widget(303);
+    tick_user_widget_ok_cancel_widget(310);
+    tick_user_widget_ok_cancel_widget(318);
+    tick_user_widget_ok_cancel_widget(326);
+    tick_user_widget_ok_cancel_widget(333);
+    tick_user_widget_ok_cancel_widget(339);
+    tick_user_widget_ok_cancel_widget(346);
+    tick_user_widget_ok_cancel_widget(354);
+    tick_user_widget_ok_cancel_widget(360);
+    tick_user_widget_ok_cancel_widget(373);
+    tick_user_widget_ok_cancel_widget(479);
 }
 
 void create_screen_blank_screen() {

--- a/generated/ui_320x240/screens.h
+++ b/generated/ui_320x240/screens.h
@@ -197,6 +197,7 @@ typedef struct _objects_t {
     lv_obj_t *map_style_dropdown;
     lv_obj_t *map_url_dropdown;
     lv_obj_t *map_location_label;
+    lv_obj_t *map_attribution_label;
     lv_obj_t *google_logo_image;
     lv_obj_t *controller_panel;
     lv_obj_t *controller_tab_view;

--- a/include/graphics/map/MapTileSettings.h
+++ b/include/graphics/map/MapTileSettings.h
@@ -48,8 +48,11 @@ class MapTileSettings
     static const char *getTileFormat(void) { return tileFormat; }
     static void setTileFormat(const char *p) { copyBounded(tileFormat, TILE_FORMAT_SIZE, p); }
 
-    static uint16_t getTileProvider(void) { return tileProviderId; }
-    static void setTileProvider(uint16_t id) { tileProviderId = id; }
+    static int16_t getTileProvider(void) { return tileProviderId; }
+    static void setTileProvider(int16_t id) { tileProviderId = id; }
+
+    static uint32_t getUniqueId(void) { return uniqueId; }
+    static void setUniqueId(uint32_t id) { uniqueId = id; }
 
     static bool color(void) { return colorTiles; }
     static void setColor(bool on) { colorTiles = on; }
@@ -78,9 +81,10 @@ class MapTileSettings
     static uint8_t zoomLevel;
     static uint8_t zoomDefault;
     static uint16_t tileSize;
-    static uint16_t tileProviderId;
+    static int16_t tileProviderId;
     static bool colorTiles;
     static uint32_t cacheSize;
+    static uint32_t uniqueId;
     static float defaultLat;
     static float defaultLon;
     static char prefix[];

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2687,8 +2687,7 @@ void TFTView_320x240::loadMap(void)
                 if (!providers.empty()) {
                     lv_dropdown_set_options(objects.map_url_dropdown, providers.c_str());
                     lv_dropdown_set_selected(objects.map_url_dropdown, TileProvider::selectedTemplate());
-                }
-                else {
+                } else {
                     lv_dropdown_clear_options(objects.map_url_dropdown);
                 }
                 if (!savedStyleOK) {
@@ -2797,8 +2796,7 @@ void TFTView_320x240::attribution(std::string url)
     } else if (url.find("openstreetmap") != std::string::npos) {
         lv_label_set_text(objects.map_attribution_label, "\xC2\xA9 OpenStreetMap");
         lv_obj_remove_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
-    }
-    else {
+    } else {
         lv_obj_add_flag(objects.google_logo_image, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
     }

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2793,9 +2793,11 @@ void TFTView_320x240::attribution(std::string url)
     // set google overlay attribution
     if (url.find("google") != std::string::npos) {
         lv_obj_remove_flag(objects.google_logo_image, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
     } else if (url.find("openstreetmap") != std::string::npos) {
         lv_label_set_text(objects.map_attribution_label, "\xC2\xA9 OpenStreetMap");
         lv_obj_remove_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(objects.google_logo_image, LV_OBJ_FLAG_HIDDEN);
     } else {
         lv_obj_add_flag(objects.google_logo_image, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2683,9 +2683,14 @@ void TFTView_320x240::loadMap(void)
                         }
                     }
                 }
-                lv_dropdown_set_options(objects.map_url_dropdown, TileProvider::providers().c_str());
-                lv_dropdown_set_selected(objects.map_url_dropdown, TileProvider::selectedTemplate());
-
+                auto providers = TileProvider::providers();
+                if (!providers.empty()) {
+                    lv_dropdown_set_options(objects.map_url_dropdown, providers.c_str());
+                    lv_dropdown_set_selected(objects.map_url_dropdown, TileProvider::selectedTemplate());
+                }
+                else {
+                    lv_dropdown_clear_options(objects.map_url_dropdown);
+                }
                 if (!savedStyleOK) {
                     // no such style on SD, pick first one we found
                     char style[30];
@@ -2702,8 +2707,10 @@ void TFTView_320x240::loadMap(void)
             map->forceRedraw();
         }
     } else {
-        lv_dropdown_set_options(objects.map_style_dropdown, "");
+        lv_dropdown_clear_options(objects.map_style_dropdown);
     }
+
+    MapTileSettings::setUniqueId(ownNode);
 
     lv_obj_clear_flag(objects.map_panel, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(objects.raw_map_panel, LV_OBJ_FLAG_HIDDEN);
@@ -2787,8 +2794,13 @@ void TFTView_320x240::attribution(std::string url)
     // set google overlay attribution
     if (url.find("google") != std::string::npos) {
         lv_obj_remove_flag(objects.google_logo_image, LV_OBJ_FLAG_HIDDEN);
-    } else {
+    } else if (url.find("openstreetmap") != std::string::npos) {
+        lv_label_set_text(objects.map_attribution_label, "\xC2\xA9 OpenStreetMap");
+        lv_obj_remove_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
+    }
+    else {
         lv_obj_add_flag(objects.google_logo_image, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
     }
 }
 

--- a/source/graphics/map/CURLService.cpp
+++ b/source/graphics/map/CURLService.cpp
@@ -112,15 +112,12 @@ bool CURLService::load(const char *name, void *img)
 
     headers.list = curl_slist_append(headers.list, "Accept: image/png,image/*;q=0.9,*/*;q=0.8");
     headers.list = curl_slist_append(headers.list, "Connection: keep-alive");
-    if (url.find("google.com") != std::string::npos) {
-        headers.list = curl_slist_append(headers.list, "Referer: https://www.google.com/");
-    }
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buf);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers.list);
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "MUI/1.0 (+https://meshtastic.org)");
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "MUI/2.8 (+https://meshtastic.org)");
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, CURL_CONNECT_TIMEOUT_MS);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, CURL_REQUEST_TIMEOUT_MS);

--- a/source/graphics/map/CURLService.cpp
+++ b/source/graphics/map/CURLService.cpp
@@ -87,7 +87,6 @@ bool CURLService::load(const char *name, void *img)
 
     std::string url = TileProvider::url(name);
     if (url.empty()) {
-        ILOG_ERROR("empty URL for tile %s", name ? name : "(null)");
         return false;
     }
 

--- a/source/graphics/map/MapTileSettings.cpp
+++ b/source/graphics/map/MapTileSettings.cpp
@@ -5,8 +5,9 @@
 uint8_t MapTileSettings::zoomLevel = 13;   // current zoomLevel
 uint8_t MapTileSettings::zoomDefault = 13; // default for initial or home position
 uint16_t MapTileSettings::tileSize = 256;
-uint16_t MapTileSettings::tileProviderId = 0;       // default url index to load from (backup service)
+int16_t MapTileSettings::tileProviderId = -1;       // default url index to load from (backup service)
 uint32_t MapTileSettings::cacheSize = 50 * 1024;    // LV_FS_CACHE_FROM_BUFFER
+uint32_t MapTileSettings::uniqueId = 0xFFFFFFFF;    // to be updated with node number
 float MapTileSettings::defaultLat = 51.5003646652f; // @theBigBentern
 float MapTileSettings::defaultLon = -0.1214328476f;
 char MapTileSettings::prefix[MapTileSettings::PREFIX_SIZE] = "/maps";        // default map tile directory

--- a/source/graphics/map/TileProvider.cpp
+++ b/source/graphics/map/TileProvider.cpp
@@ -48,7 +48,7 @@ const std::string TileProvider::url(void)
 {
     std::string provider, url;
     int16_t providerId = MapTileSettings::getTileProvider();
-    if (providerId >= 0)  {
+    if (providerId >= 0) {
         std::tie(provider, url) = urlTemplates[providerId];
     }
     return url;

--- a/source/graphics/map/TileProvider.cpp
+++ b/source/graphics/map/TileProvider.cpp
@@ -3,8 +3,7 @@
 #include "util/ILog.h"
 #include <algorithm>
 
-std::vector<std::tuple<std::string, std::string>> TileProvider::urlTemplates = {
-    {"URL: Google Maps", "https://mt0.google.com/vt?lyrs=m&x={x}&s=&y={y}&z={z}"}};
+std::vector<std::tuple<std::string, std::string>> TileProvider::urlTemplates;
 
 std::string TileProvider::url(const char *filename)
 {
@@ -22,7 +21,7 @@ std::string TileProvider::url(int z, int x, int y)
 {
     std::string provider, url;
     if (urlTemplates.empty()) {
-        ILOG_ERROR("no URL templates available");
+        ILOG_WARN("no URL templates available");
         return "";
     }
 
@@ -48,7 +47,10 @@ std::string TileProvider::url(int z, int x, int y)
 const std::string TileProvider::url(void)
 {
     std::string provider, url;
-    std::tie(provider, url) = urlTemplates[MapTileSettings::getTileProvider()];
+    int16_t providerId = MapTileSettings::getTileProvider();
+    if (providerId >= 0)  {
+        std::tie(provider, url) = urlTemplates[providerId];
+    }
     return url;
 }
 

--- a/source/graphics/map/TileProvider.cpp
+++ b/source/graphics/map/TileProvider.cpp
@@ -20,17 +20,16 @@ std::string TileProvider::url(const char *filename)
 std::string TileProvider::url(int z, int x, int y)
 {
     std::string provider, url;
-    if (urlTemplates.empty()) {
-        ILOG_WARN("no URL templates available");
-        return "";
+    if (urlTemplates.empty() || MapTileSettings::getTileProvider() == -1) {
+        ILOG_WARN("no URL template available");
+        return url;
     }
 
-    size_t selected = MapTileSettings::getTileProvider();
+    int16_t selected = MapTileSettings::getTileProvider();
     if (selected >= urlTemplates.size()) {
         ILOG_WARN("tile provider index out of range: %u (max %u)", (unsigned int)selected,
                   (unsigned int)(urlTemplates.size() - 1));
-        selected = 0;
-        MapTileSettings::setTileProvider(0);
+        return url;
     }
 
     std::tie(provider, url) = urlTemplates[selected];

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -92,8 +92,8 @@ bool URLService::load(const char *name, void *img)
 
         // read .png file in chunks to increase reliability (avoid readBytes())
         size_t bytesRead = 0;
-        uint8_t idleSpins = 0;
-        const uint8_t maxIdleSpins = MUI_MAX_IDLE_SPINS;
+        uint16_t idleSpins = 0;
+        const uint16_t maxIdleSpins = MUI_MAX_IDLE_SPINS;
         while (bytesRead < len) {
             size_t available = stream->available();
             if (available == 0) {

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -41,7 +41,6 @@ bool URLService::load(const char *name, void *img)
 
     std::string url = TileProvider::url(name);
     if (url.empty()) {
-        ILOG_ERROR("empty URL for tile %s", name ? name : "(null)");
         return false;
     }
 

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -61,9 +61,8 @@ bool URLService::load(const char *name, void *img)
         http.addHeader("Connection", "close");
         // generate a unique, policy-compliant User-Agent
         char userAgentBuf[128];
-        snprintf(userAgentBuf, sizeof(userAgentBuf), 
-                 "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.com", unique_id);
-        
+        snprintf(userAgentBuf, sizeof(userAgentBuf), "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.com", unique_id);
+
         http.setUserAgent(userAgentBuf);
         http.setTimeout(MUI_MAX_TLS_TIMEOUT);
 

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -45,8 +45,16 @@ bool URLService::load(const char *name, void *img)
         return false;
     }
 
-    uint8_t *pngImage = nullptr;
     size_t len = 0;
+    uint8_t *pngImage = nullptr;
+    struct LvFreeGuard {
+        uint8_t *&ptr;
+        ~LvFreeGuard()
+        {
+            if (ptr)
+                lv_free(ptr);
+        }
+    } pngGuard{pngImage};
 
     {
         HTTPClient http;
@@ -87,11 +95,6 @@ bool URLService::load(const char *name, void *img)
             http.end();
             return false;
         }
-
-        struct LvFreeGuard {
-            uint8_t *&ptr;
-            ~LvFreeGuard() { lv_free(ptr); }
-        } pngGuard{pngImage};
 
         WiFiClient *stream = http.getStreamPtr();
         if (!stream) {

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -51,7 +51,7 @@ bool URLService::load(const char *name, void *img)
     {
         HTTPClient http;
         http.setReuse(false);
-        
+
         if (!http.begin(url.c_str())) {
             ILOG_ERROR("ERROR begin %s", url.c_str());
             return false;
@@ -59,11 +59,13 @@ bool URLService::load(const char *name, void *img)
 
         http.addHeader("Accept", "image/png,image/*;q=0.9,*/*;q=0.8");
         http.addHeader("Connection", "close");
-        if (url.find("google.com") != std::string::npos) {
-            http.addHeader("Referer", "https://google.com");
-        }
-        http.setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-        http.setTimeout(MUI_MAX_TLS_TIMEOUT); 
+        // generate a unique, policy-compliant User-Agent
+        char userAgentBuf[128];
+        snprintf(userAgentBuf, sizeof(userAgentBuf), 
+                 "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.com", unique_id);
+        
+        http.setUserAgent(userAgentBuf);
+        http.setTimeout(MUI_MAX_TLS_TIMEOUT);
 
         int httpCode = http.GET();
         if (httpCode != HTTP_CODE_OK) {
@@ -80,7 +82,6 @@ bool URLService::load(const char *name, void *img)
         }
 
         len = (size_t)contentLen;
-        
         pngImage = (uint8_t *)lv_malloc(len);
         if (!pngImage) {
             ILOG_ERROR("lv_malloc failed for %s (%u bytes)", url.c_str(), (unsigned int)len);
@@ -88,7 +89,17 @@ bool URLService::load(const char *name, void *img)
             return false;
         }
 
+        struct LvFreeGuard {
+            uint8_t *&ptr;
+            ~LvFreeGuard() { lv_free(ptr); }
+        } pngGuard{pngImage};
+
         WiFiClient *stream = http.getStreamPtr();
+        if (!stream) {
+            ILOG_ERROR("no WiFiClient stream");
+            http.end();
+            return false;
+        }
 
         // read .png file in chunks to increase reliability (avoid readBytes())
         size_t bytesRead = 0;
@@ -120,15 +131,14 @@ bool URLService::load(const char *name, void *img)
 
         if (bytesRead != len) {
             ILOG_ERROR("http read error %s : %u != %u", url.c_str(), (unsigned int)bytesRead, (unsigned int)len);
-            lv_free(pngImage);
             http.end();
             return false;
         }
 
-        http.end(); 
+        http.end();
 
         ILOG_DEBUG("SUCCESS: GET %s (%u bytes)", url.c_str(), (unsigned int)len);
-    } 
+    }
 
     // Decode png
     lv_img_dsc_t *img_dsc = nullptr;
@@ -142,23 +152,19 @@ bool URLService::load(const char *name, void *img)
                 lv_free((void *)img_dsc->data);
             }
             lv_free(img_dsc);
-            lv_free(pngImage);
             return false;
         }
     } else {
         ILOG_ERROR("Failed to decode tile image %s", name);
-        lv_free(pngImage);
         return false;
     }
 
     if (saveCB && MapTileSettings::saveOK()) {
         bool saveResult = saveCB(name, pngImage, len);
         ILOG_DEBUG("save png to SD -> %s", saveResult ? "OK" : "failed");
-        lv_free(pngImage);
         return true;
     }
 
-    lv_free(pngImage);
     return true;
 }
 

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -9,6 +9,15 @@
 
 #include "HTTPClient.h" // not available on Linux/Portduino
 #include "WiFi.h"
+#include "esp_wifi.h"
+
+#ifndef MUI_MAX_TLS_TIMEOUT
+#define MUI_MAX_TLS_TIMEOUT 2000
+#endif
+
+#ifndef MUI_MAX_IDLE_SPINS
+#define MUI_MAX_IDLE_SPINS 100
+#endif
 
 URLService::URLService(Callback cb) : ITileService("HTTP:"), saveCB(cb)
 {
@@ -19,95 +28,109 @@ URLService::~URLService() {}
 
 bool URLService::load(const char *name, void *img)
 {
-    HTTPClient http;
-
     if (WiFi.status() != WL_CONNECTED) {
         ILOG_DEBUG("URLService::load skipped (WiFi not connected)");
         return false;
     }
 
-    struct LvFreeGuard {
-        uint8_t *&ptr;
-        ~LvFreeGuard() { lv_free(ptr); }
-    };
+#ifdef MUI_WIFI_PS_MIN_MODEM
+    esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
+#elif defined(MUI_WIFI_PS_NONE)
+    esp_wifi_set_ps(WIFI_PS_NONE);
+#endif
 
-    // transform filename to provider url
     std::string url = TileProvider::url(name);
     if (url.empty()) {
         ILOG_ERROR("empty URL for tile %s", name ? name : "(null)");
         return false;
     }
 
-    http.setReuse(false);
-    if (!http.begin(url.c_str())) {
-        ILOG_ERROR("ERROR begin %s", url.c_str());
-        return false;
-    }
+    uint8_t *pngImage = nullptr;
+    size_t len = 0;
 
-    int httpCode = http.GET();
-    if (httpCode != HTTP_CODE_OK) {
-        ILOG_ERROR("ERROR GET %s : %d", url.c_str(), httpCode);
-        return false;
-    }
+    {
+        HTTPClient http;
+        http.setReuse(false);
+        
+        if (!http.begin(url.c_str())) {
+            ILOG_ERROR("ERROR begin %s", url.c_str());
+            return false;
+        }
 
-    WiFiClient *stream = http.getStreamPtr();
-    int contentLen = http.getSize();
-    if (contentLen <= 0) {
-        ILOG_WARN("GET %s : empty", url.c_str());
-        return false;
-    }
+        http.addHeader("Accept", "image/png,image/*;q=0.9,*/*;q=0.8");
+        http.addHeader("Connection", "close");
+        if (url.find("google.com") != std::string::npos) {
+            http.addHeader("Referer", "https://google.com");
+        }
+        http.setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+        http.setTimeout(MUI_MAX_TLS_TIMEOUT); 
 
-    size_t len = (size_t)contentLen;
+        int httpCode = http.GET();
+        if (httpCode != HTTP_CODE_OK) {
+            ILOG_ERROR("ERROR GET %s : %d", url.c_str(), httpCode);
+            http.end();
+            return false;
+        }
 
-    uint8_t *pngImage = (uint8_t *)lv_malloc(len);
-    LvFreeGuard pngGuard{pngImage};
-    if (!pngImage) {
-        ILOG_ERROR("lv_malloc failed for %s (%u bytes)", url.c_str(), (unsigned int)len);
-        return false;
-    }
+        int contentLen = http.getSize();
+        if (contentLen <= 0) {
+            ILOG_WARN("GET %s : empty", url.c_str());
+            http.end();
+            return false;
+        }
 
-    // read .png file in chunks to increase reliability (avoid readBytes())
-    size_t bytesRead = 0;
-    uint8_t idleSpins = 0;
-    const uint8_t maxIdleSpins = 3;
-    while (bytesRead < len) {
-        size_t available = stream->available();
-        if (available == 0) {
-            if (++idleSpins > maxIdleSpins) {
+        len = (size_t)contentLen;
+        
+        pngImage = (uint8_t *)lv_malloc(len);
+        if (!pngImage) {
+            ILOG_ERROR("lv_malloc failed for %s (%u bytes)", url.c_str(), (unsigned int)len);
+            http.end();
+            return false;
+        }
+
+        WiFiClient *stream = http.getStreamPtr();
+
+        // read .png file in chunks to increase reliability (avoid readBytes())
+        size_t bytesRead = 0;
+        uint8_t idleSpins = 0;
+        const uint8_t maxIdleSpins = MUI_MAX_IDLE_SPINS;
+        while (bytesRead < len) {
+            size_t available = stream->available();
+            if (available == 0) {
+                if (++idleSpins > maxIdleSpins) {
+                    break;
+                }
+                delay(5);
+                continue;
+            }
+
+            idleSpins = 0;
+            size_t toRead = available;
+            size_t remaining = len - bytesRead;
+            if (toRead > remaining) {
+                toRead = remaining;
+            }
+
+            int got = stream->read(pngImage + bytesRead, toRead);
+            if (got <= 0) {
                 break;
             }
-            delay(5);
-            continue;
+            bytesRead += (size_t)got;
         }
 
-        idleSpins = 0;
-        size_t toRead = available;
-        size_t remaining = len - bytesRead;
-        if (toRead > remaining) {
-            toRead = remaining;
+        if (bytesRead != len) {
+            ILOG_ERROR("http read error %s : %u != %u", url.c_str(), (unsigned int)bytesRead, (unsigned int)len);
+            lv_free(pngImage);
+            http.end();
+            return false;
         }
 
-        int got = stream->read(pngImage + bytesRead, toRead);
-        if (got <= 0) {
-            break;
-        }
-        bytesRead += (size_t)got;
-    }
+        http.end(); 
 
-    if (bytesRead != len) {
-        ILOG_ERROR("http read error %s : %u != %u", url.c_str(), (unsigned int)bytesRead, (unsigned int)len);
-        return false;
-    }
+        ILOG_DEBUG("SUCCESS: GET %s (%u bytes)", url.c_str(), (unsigned int)len);
+    } 
 
-    ILOG_DEBUG("SUCCESS(%d): GET %s (%u bytes)", (int)idleSpins, url.c_str(), (unsigned int)len);
-
-    // save png tile to SD card
-    if (saveCB && MapTileSettings::saveOK()) {
-        bool result = saveCB(name, pngImage, len);
-        ILOG_DEBUG("save png to SD -> %s", result ? "OK" : "failed");
-    }
-
-    // decode png
+    // Decode png
     lv_img_dsc_t *img_dsc = nullptr;
     bool decoded = MapTileSettings::color() ? decodeImgColor(pngImage, len, &img_dsc) : decodeImgGrey(pngImage, len, &img_dsc);
     if (decoded) {
@@ -119,13 +142,23 @@ bool URLService::load(const char *name, void *img)
                 lv_free((void *)img_dsc->data);
             }
             lv_free(img_dsc);
+            lv_free(pngImage);
             return false;
         }
     } else {
         ILOG_ERROR("Failed to decode tile image %s", name);
+        lv_free(pngImage);
         return false;
     }
 
+    if (saveCB && MapTileSettings::saveOK()) {
+        bool saveResult = saveCB(name, pngImage, len);
+        ILOG_DEBUG("save png to SD -> %s", saveResult ? "OK" : "failed");
+        lv_free(pngImage);
+        return true;
+    }
+
+    lv_free(pngImage);
     return true;
 }
 

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -68,7 +68,7 @@ bool URLService::load(const char *name, void *img)
         http.addHeader("Connection", "close");
         // generate a unique, policy-compliant User-Agent
         char userAgentBuf[128];
-        snprintf(userAgentBuf, sizeof(userAgentBuf), "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.com", unique_id);
+        snprintf(userAgentBuf, sizeof(userAgentBuf), "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.org", unique_id);
 
         http.setUserAgent(userAgentBuf);
         http.setTimeout(MUI_MAX_TLS_TIMEOUT);

--- a/studio/320x240/TFT320x240.eez-project
+++ b/studio/320x240/TFT320x240.eez-project
@@ -5872,6 +5872,61 @@
                   "recolor": false
                 },
                 {
+                  "objID": "cbd1f266-0513-4057-a5ad-0fc5296e0a95",
+                  "type": "LVGLLabelWidget",
+                  "left": 0,
+                  "top": -1,
+                  "width": 0,
+                  "height": 17,
+                  "customInputs": [],
+                  "customOutputs": [],
+                  "style": {
+                    "objID": "f09eebe0-8307-45c5-f13e-eef35e781ae2",
+                    "useStyle": "default",
+                    "conditionalStyles": [],
+                    "childStyles": []
+                  },
+                  "hiddenInEditor": false,
+                  "timeline": [],
+                  "eventHandlers": [],
+                  "identifier": "mapAttributionLabel",
+                  "leftUnit": "px",
+                  "topUnit": "px",
+                  "widthUnit": "content",
+                  "heightUnit": "content",
+                  "children": [],
+                  "widgetFlags": "",
+                  "hiddenFlagType": "literal",
+                  "clickableFlagType": "literal",
+                  "flagScrollbarMode": "",
+                  "flagScrollDirection": "",
+                  "scrollSnapX": "",
+                  "scrollSnapY": "",
+                  "checkedStateType": "literal",
+                  "disabledStateType": "literal",
+                  "states": "",
+                  "useStyle": "",
+                  "localStyles": {
+                    "objID": "cae16d05-a0b9-4dfa-ff11-a68039ff2c97",
+                    "definition": {
+                      "MAIN": {
+                        "DEFAULT": {
+                          "align": "BOTTOM_MID",
+                          "text_font": "montserrat_12",
+                          "text_color": "#212121",
+                          "text_opa": 200
+                        }
+                      }
+                    }
+                  },
+                  "group": "",
+                  "groupIndex": 0,
+                  "text": "",
+                  "textType": "literal",
+                  "longMode": "CLIP",
+                  "recolor": false
+                },
+                {
                   "objID": "6bfa7245-35c9-46f7-e4a7-b64a32a640fd",
                   "type": "LVGLImageWidget",
                   "left": 0,


### PR DESCRIPTION
This PR fixes some issues when downloading HTTP map tiles:
- increased default GET file transfer timeouts/retries to avoid blank tiles
- seperate WiFi download and SD card write which can cause interference
- added HTTP header info and corrected other legal stuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved reliability when downloading, decoding, and saving map tiles.
- Added better handling for connection timeouts, stalled responses, and failed downloads.
- Improved Wi-Fi power-mode handling during map downloads.
- Improved behavior when no map tile providers are configured.

## Improvements
- Added clearer OpenStreetMap attribution and hid attribution when it is not applicable.
- Improved map provider selection and settings persistence.
- Updated map service requests for more consistent loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->