### PR TITLE
fix: merge error PR362

### DIFF
--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -68,7 +68,8 @@ bool URLService::load(const char *name, void *img)
         http.addHeader("Connection", "close");
         // generate a unique, policy-compliant User-Agent
         char userAgentBuf[128];
-        snprintf(userAgentBuf, sizeof(userAgentBuf), "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.org", unique_id);
+        snprintf(userAgentBuf, sizeof(userAgentBuf),
+                 "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.org", MapTileSettings::getUniqueId());
 
         http.setUserAgent(userAgentBuf);
         http.setTimeout(MUI_MAX_TLS_TIMEOUT);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 map tile requests by using the device’s current unique identifier in the HTTP User-Agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->