### PR TITLE
fix: SPI lock; revert http flags

### DIFF
--- a/include/graphics/map/URLService.h
+++ b/include/graphics/map/URLService.h
@@ -4,6 +4,7 @@
 #include <functional>
 
 #ifdef ARDUINO_ARCH_ESP32
+#include "HTTPClient.h"
 
 class URLService : public ITileService
 {
@@ -16,6 +17,7 @@ class URLService : public ITileService
 
   private:
     Callback saveCB = nullptr;
+    HTTPClient http;
 };
 
 #endif

--- a/source/graphics/map/SDCardService.cpp
+++ b/source/graphics/map/SDCardService.cpp
@@ -90,33 +90,36 @@ bool SDCardService::load(const char *name, void *img)
         return false;
     }
 #else
-    // optimized PNGdec decoding
-    File file = SD.open(name, FILE_READ);
-    if (!file) {
-        ILOG_DEBUG("Failed to open tile %s from SD", name);
-        return false;
-    }
+    {
+        ISpiLock::Guard bus;
+        // optimized PNGdec decoding
+        File file = SD.open(name, FILE_READ);
+        if (!file) {
+            ILOG_DEBUG("Failed to open tile %s from SD", name);
+            return false;
+        }
 
-    size_t len = (size_t)file.size();
-    if (len == 0) {
-        ILOG_DEBUG("Tile %s is empty", name);
+        size_t len = (size_t)file.size();
+        if (len == 0) {
+            ILOG_DEBUG("Tile %s is empty", name);
+            file.close();
+            return false;
+        }
+
+        uint8_t *pngImage = (uint8_t *)lv_malloc(len);
+        if (!pngImage) {
+            ILOG_ERROR("lv_malloc failed for %s (%u bytes)", name, (unsigned int)len);
+            file.close();
+            return false;
+        }
+
+        size_t bytesRead = file.read(pngImage, len);
         file.close();
-        return false;
-    }
-
-    uint8_t *pngImage = (uint8_t *)lv_malloc(len);
-    if (!pngImage) {
-        ILOG_ERROR("lv_malloc failed for %s (%u bytes)", name, (unsigned int)len);
-        file.close();
-        return false;
-    }
-
-    size_t bytesRead = file.read(pngImage, len);
-    file.close();
-    if (bytesRead != len) {
-        ILOG_ERROR("read error %s : %u != %u", name, (unsigned int)bytesRead, (unsigned int)len);
-        lv_free(pngImage);
-        return false;
+        if (bytesRead != len) {
+            ILOG_ERROR("read error %s : %u != %u", name, (unsigned int)bytesRead, (unsigned int)len);
+            lv_free(pngImage);
+            return false;
+        }
     }
 
     lv_img_dsc_t *img_dsc = nullptr;
@@ -145,6 +148,7 @@ bool SDCardService::load(const char *name, void *img)
 
 bool SDCardService::save(const char *name, void *img, size_t len)
 {
+    ISpiLock::Guard bus;
     ILOG_DEBUG("SDCardService::save(%s): %d", name, len);
     if (!ensureParentDirectories(name)) {
         return false;

--- a/source/graphics/map/SdFatService.cpp
+++ b/source/graphics/map/SdFatService.cpp
@@ -1,4 +1,4 @@
-#if defined(HAS_SDCARD) && not defined(HAS_SD_MMC) && not defined(ARCH_PORTDUINO)
+#if defined(HAS_SDCARD) && not defined(HAS_SD_MMC) && not defined(ARCH_PORTDUINO) && not defined(SDCARD_SHARE_SPI)
 
 #include "lvgl.h"
 #include "util/ISpiLock.h"
@@ -13,6 +13,32 @@
 #include <utility>
 
 #define DRIVE_LETTER "S"
+
+static bool ensureParentDirectories(const char *path)
+{
+    std::string fullPath(path);
+    const size_t lastSlash = fullPath.rfind('/');
+    if (lastSlash == std::string::npos || lastSlash == 0) {
+        return true;
+    }
+
+    const std::string directory = fullPath.substr(0, lastSlash);
+    size_t searchPos = 1;
+    while (searchPos <= directory.size()) {
+        const size_t slashPos = directory.find('/', searchPos);
+        const std::string currentDir = slashPos == std::string::npos ? directory : directory.substr(0, slashPos);
+        if (!currentDir.empty() && !SDFs.exists(currentDir.c_str()) && !SDFs.mkdir(currentDir.c_str())) {
+            ILOG_ERROR("failed to create directory %s", currentDir.c_str());
+            return false;
+        }
+        if (slashPos == std::string::npos) {
+            break;
+        }
+        searchPos = slashPos + 1;
+    }
+
+    return true;
+}
 
 SdFatService::SdFatService() : ITileService(DRIVE_LETTER ":")
 {
@@ -56,35 +82,38 @@ bool SdFatService::load(const char *name, void *img)
         return false;
     }
 #else
-    // optimized PNGdec decoding
-    FsFile file = SDFs.open(name, O_RDONLY);
-    if (!file) {
-        ILOG_DEBUG("Failed to open tile %s from SD", name);
-        return false;
-    }
+    {
+        ISpiLock::Guard bus;
 
-    size_t len = (size_t)file.size();
-    if (len == 0) {
-        ILOG_DEBUG("Tile %s is empty", name);
+        // optimized PNGdec decoding
+        FsFile file = SDFs.open(name, O_RDONLY);
+        if (!file) {
+            ILOG_DEBUG("Failed to open tile %s from SD", name);
+            return false;
+        }
+
+        size_t len = (size_t)file.size();
+        if (len == 0) {
+            ILOG_DEBUG("Tile %s is empty", name);
+            file.close();
+            return false;
+        }
+
+        uint8_t *pngImage = (uint8_t *)lv_malloc(len);
+        if (!pngImage) {
+            ILOG_ERROR("lv_malloc failed for %s (%u bytes)", name, (unsigned int)len);
+            file.close();
+            return false;
+        }
+
+        size_t bytesRead = file.read(pngImage, len);
         file.close();
-        return false;
+        if (bytesRead != len) {
+            ILOG_ERROR("read error %s : %u != %u", name, (unsigned int)bytesRead, (unsigned int)len);
+            lv_free(pngImage);
+            return false;
+        }
     }
-
-    uint8_t *pngImage = (uint8_t *)lv_malloc(len);
-    if (!pngImage) {
-        ILOG_ERROR("lv_malloc failed for %s (%u bytes)", name, (unsigned int)len);
-        file.close();
-        return false;
-    }
-
-    size_t bytesRead = file.read(pngImage, len);
-    file.close();
-    if (bytesRead != len) {
-        ILOG_ERROR("read error %s : %u != %u", name, (unsigned int)bytesRead, (unsigned int)len);
-        lv_free(pngImage);
-        return false;
-    }
-
     lv_img_dsc_t *img_dsc = nullptr;
     bool decoded = MapTileSettings::color() ? decodeImgColor(pngImage, len, &img_dsc) : decodeImgGrey(pngImage, len, &img_dsc);
     lv_free(pngImage);
@@ -112,16 +141,10 @@ bool SdFatService::load(const char *name, void *img)
 bool SdFatService::save(const char *name, void *img, size_t len)
 {
     ILOG_DEBUG("SdFatService::save(%s): %d", name, len);
-    // create intermediate directories for path (e.g. /maps/atlas/12/2198/1341.png)
-    std::string directory;
-    std::string filename(name);
-    const size_t last_slash_idx = filename.rfind('/');
-    if (std::string::npos == last_slash_idx) {
-        // something went wrong
+    ISpiLock::Guard bus;
+    if (!ensureParentDirectories(name)) {
         return false;
     }
-    directory = filename.substr(0, last_slash_idx);
-    SDFs.mkdir(directory.c_str());
 
     // write image
     FsFile file = SDFs.open(name, O_RDWR | O_CREAT);
@@ -142,7 +165,7 @@ void *SdFatService::fs_open(lv_fs_drv_t *drv, const char *path, lv_fs_mode_t mod
     SdFile *lf = new SdFile;
     lf->file = SDFs.open(path, mode == LV_FS_MODE_RD ? O_RDONLY : O_WRONLY); // NOTE: O_RDWR
     if (!lf->file) {
-        // ILOG_DEBUG("FsSD.open() %s failed!", path);
+        // ILOG_DEBUG("SDFs.open() %s failed!", path);
         delete lf;
         return nullptr;
     } else {
@@ -153,7 +176,7 @@ void *SdFatService::fs_open(lv_fs_drv_t *drv, const char *path, lv_fs_mode_t mod
 lv_fs_res_t SdFatService::fs_close(lv_fs_drv_t *drv, void *file_p)
 {
     ISpiLock::Guard bus;
-    // ILOG_DEBUG("FsSD.close()");
+    // ILOG_DEBUG("SDFs.close()");
     SdFile *lf = static_cast<SdFile *>(file_p);
     lf->file.close();
     delete lf;
@@ -164,7 +187,7 @@ lv_fs_res_t SdFatService::fs_read(lv_fs_drv_t *drv, void *file_p, void *buf, uin
 {
     ISpiLock::Guard bus;
     *br = static_cast<SdFile *>(file_p)->file.read((uint8_t *)buf, btr);
-    // ILOG_DEBUG("FsSD.read(): %d/%d bytes", *br, btr);
+    // ILOG_DEBUG("SDFs.read(): %d/%d bytes", *br, btr);
     return (*br <= 0) ? LV_FS_RES_UNKNOWN : LV_FS_RES_OK;
 }
 
@@ -172,14 +195,14 @@ lv_fs_res_t SdFatService::fs_write(lv_fs_drv_t *drv, void *file_p, const void *b
 {
     ISpiLock::Guard bus;
     *bw = static_cast<SdFile *>(file_p)->file.write((uint8_t *)buf, btw);
-    // ILOG_DEBUG("FsSD.write(): %d/btw bytes", *bw, btw);
+    // ILOG_DEBUG("SDFs.write(): %d/btw bytes", *bw, btw);
     return (*bw <= 0) ? LV_FS_RES_UNKNOWN : LV_FS_RES_OK;
 }
 
 lv_fs_res_t SdFatService::fs_seek(lv_fs_drv_t *drv, void *file_p, uint32_t pos, lv_fs_whence_t whence)
 {
     ISpiLock::Guard bus;
-    // ILOG_DEBUG("FsSD.seek(): pos %d", pos);
+    // ILOG_DEBUG("SDFs.seek(): pos %d", pos);
     if (whence == LV_FS_SEEK_SET) {
         return static_cast<SdFile *>(file_p)->file.seekSet(pos) ? LV_FS_RES_OK : LV_FS_RES_UNKNOWN;
     } else if (whence == LV_FS_SEEK_END) {
@@ -193,7 +216,7 @@ lv_fs_res_t SdFatService::fs_tell(lv_fs_drv_t *drv, void *file_p, uint32_t *pos_
 {
     ISpiLock::Guard bus;
     *pos_p = static_cast<SdFile *>(file_p)->file.position();
-    // ILOG_DEBUG("FsSD.tell(): pos %d", *pos_p);
+    // ILOG_DEBUG("SDFs.tell(): pos %d", *pos_p);
     return (int32_t)(*pos_p) < 0 ? LV_FS_RES_UNKNOWN : LV_FS_RES_OK;
 }
 

--- a/source/graphics/map/URLService.cpp
+++ b/source/graphics/map/URLService.cpp
@@ -7,7 +7,6 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
-#include "HTTPClient.h" // not available on Linux/Portduino
 #include "WiFi.h"
 #include "esp_wifi.h"
 
@@ -54,93 +53,87 @@ bool URLService::load(const char *name, void *img)
                 lv_free(ptr);
         }
     } pngGuard{pngImage};
+    http.setReuse(true);
 
-    {
-        HTTPClient http;
-        http.setReuse(false);
+    if (!http.begin(url.c_str())) {
+        ILOG_ERROR("ERROR begin %s", url.c_str());
+        return false;
+    }
 
-        if (!http.begin(url.c_str())) {
-            ILOG_ERROR("ERROR begin %s", url.c_str());
-            return false;
-        }
+    http.addHeader("Accept", "image/png,image/*;q=0.9,*/*;q=0.8");
+    http.addHeader("Connection", "keep-alive");
+    // generate a unique, policy-compliant User-Agent
+    char userAgentBuf[128];
+    snprintf(userAgentBuf, sizeof(userAgentBuf), "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.org",
+             MapTileSettings::getUniqueId());
 
-        http.addHeader("Accept", "image/png,image/*;q=0.9,*/*;q=0.8");
-        http.addHeader("Connection", "close");
-        // generate a unique, policy-compliant User-Agent
-        char userAgentBuf[128];
-        snprintf(userAgentBuf, sizeof(userAgentBuf),
-                 "meshtastic/2.8 (ESP32; ID-%08X) contact@meshtastic.org", MapTileSettings::getUniqueId());
+    http.setUserAgent(userAgentBuf);
+    http.setTimeout(MUI_MAX_TLS_TIMEOUT);
 
-        http.setUserAgent(userAgentBuf);
-        http.setTimeout(MUI_MAX_TLS_TIMEOUT);
+    int httpCode = http.GET();
+    if (httpCode != HTTP_CODE_OK) {
+        ILOG_ERROR("ERROR GET %s : %d", url.c_str(), httpCode);
+        http.end();
+        return false;
+    }
 
-        int httpCode = http.GET();
-        if (httpCode != HTTP_CODE_OK) {
-            ILOG_ERROR("ERROR GET %s : %d", url.c_str(), httpCode);
-            http.end();
-            return false;
-        }
+    int contentLen = http.getSize();
+    if (contentLen <= 0) {
+        ILOG_WARN("GET %s : empty", url.c_str());
+        http.end();
+        return false;
+    }
 
-        int contentLen = http.getSize();
-        if (contentLen <= 0) {
-            ILOG_WARN("GET %s : empty", url.c_str());
-            http.end();
-            return false;
-        }
+    len = (size_t)contentLen;
+    pngImage = (uint8_t *)lv_malloc(len);
+    if (!pngImage) {
+        ILOG_ERROR("lv_malloc failed for %s (%u bytes)", url.c_str(), (unsigned int)len);
+        http.end();
+        return false;
+    }
 
-        len = (size_t)contentLen;
-        pngImage = (uint8_t *)lv_malloc(len);
-        if (!pngImage) {
-            ILOG_ERROR("lv_malloc failed for %s (%u bytes)", url.c_str(), (unsigned int)len);
-            http.end();
-            return false;
-        }
+    WiFiClient *stream = http.getStreamPtr();
+    if (!stream) {
+        ILOG_ERROR("no WiFiClient stream");
+        http.end();
+        return false;
+    }
 
-        WiFiClient *stream = http.getStreamPtr();
-        if (!stream) {
-            ILOG_ERROR("no WiFiClient stream");
-            http.end();
-            return false;
-        }
-
-        // read .png file in chunks to increase reliability (avoid readBytes())
-        size_t bytesRead = 0;
-        uint16_t idleSpins = 0;
-        const uint16_t maxIdleSpins = MUI_MAX_IDLE_SPINS;
-        while (bytesRead < len) {
-            size_t available = stream->available();
-            if (available == 0) {
-                if (++idleSpins > maxIdleSpins) {
-                    break;
-                }
-                delay(5);
-                continue;
-            }
-
-            idleSpins = 0;
-            size_t toRead = available;
-            size_t remaining = len - bytesRead;
-            if (toRead > remaining) {
-                toRead = remaining;
-            }
-
-            int got = stream->read(pngImage + bytesRead, toRead);
-            if (got <= 0) {
+    // read .png file in chunks to increase reliability (avoid readBytes())
+    size_t bytesRead = 0;
+    uint16_t idleSpins = 0;
+    const uint16_t maxIdleSpins = MUI_MAX_IDLE_SPINS;
+    while (bytesRead < len) {
+        size_t available = stream->available();
+        if (available == 0) {
+            if (++idleSpins > maxIdleSpins) {
                 break;
             }
-            bytesRead += (size_t)got;
+            delay(5);
+            continue;
         }
 
-        if (bytesRead != len) {
-            ILOG_ERROR("http read error %s : %u != %u", url.c_str(), (unsigned int)bytesRead, (unsigned int)len);
-            http.end();
-            return false;
+        idleSpins = 0;
+        size_t toRead = available;
+        size_t remaining = len - bytesRead;
+        if (toRead > remaining) {
+            toRead = remaining;
         }
 
-        http.end();
-
-        ILOG_DEBUG("SUCCESS: GET %s (%u bytes)", url.c_str(), (unsigned int)len);
+        int got = stream->read(pngImage + bytesRead, toRead);
+        if (got <= 0) {
+            break;
+        }
+        bytesRead += (size_t)got;
     }
+
+    if (bytesRead != len) {
+        ILOG_ERROR("http read error %s : %u != %u", url.c_str(), (unsigned int)bytesRead, (unsigned int)len);
+        http.end();
+        return false;
+    }
+
+    ILOG_DEBUG("SUCCESS: GET %s (%u bytes)", url.c_str(), (unsigned int)len);
 
     // Decode png
     lv_img_dsc_t *img_dsc = nullptr;


### PR DESCRIPTION
https://github.com/meshtastic/device-ui/pull/356 introduced SPI issues when loading/saving from SD card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SD card reliability during map tile loading and saving by coordinating SPI access.
  - Added automatic creation of missing folders when saving map data.
  - Improved handling and cleanup of SD card file operations and errors.

- **Performance**
  - Optimized tile downloads by reusing HTTP connections, helping reduce connection overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->