### PR TITLE
fix: Compilation PR10908 (some targets fail)

### DIFF
--- a/include/util/ISpiLock.h
+++ b/include/util/ISpiLock.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 /**
  * @brief Host-provided mutual exclusion for an SPI bus shared with other peripherals.
  *
@@ -24,6 +26,7 @@ class ISpiLock
   public:
     virtual ~ISpiLock() = default;
     virtual void lock(void) = 0;
+    virtual void lock(uint32_t timeout) {} // dummy will be removed by pr#314
     virtual void unlock(void) = 0;
 
     /**

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -49,7 +49,7 @@ fs::FS &fileSystem = LittleFS;
 #include "graphics/map/SDCardService.h"
 #elif defined(SENSECAP_INDICATOR)
 #include "graphics/map/RemoteSDService.h"
-#elif defined(HAS_SD_MMC) || defined(SDCARD_SHARE_SPIdone)
+#elif defined(HAS_SD_MMC) || defined(SDCARD_SHARE_SPI)
 #include "graphics/map/SDCardService.h"
 #else
 #include "graphics/map/SdFatService.h"


### PR DESCRIPTION
Need a temporary dummy implementation to serve both branches firmware/develop and firmware/thinknode-m9.

The dummy will be reverted when merging device-ui/input-policy into master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected SD-card SPI-sharing configuration so the feature is enabled reliably on supported displays.
  - Added support for specifying a lock timeout when accessing shared SPI resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->