### PR TITLE
fix: Modify lock method in ISpiLock to return false

### DIFF
--- a/include/util/ISpiLock.h
+++ b/include/util/ISpiLock.h
@@ -26,7 +26,7 @@ class ISpiLock
   public:
     virtual ~ISpiLock() = default;
     virtual void lock(void) = 0;
-    virtual bool lock(uint32_t timeout) 
+    virtual bool lock(uint32_t timeout)
     {
         return false; // dummy will be removed by pr#314
     }

--- a/include/util/ISpiLock.h
+++ b/include/util/ISpiLock.h
@@ -26,7 +26,10 @@ class ISpiLock
   public:
     virtual ~ISpiLock() = default;
     virtual void lock(void) = 0;
-    virtual bool lock(uint32_t timeout) {} // dummy will be removed by pr#314
+    virtual bool lock(uint32_t timeout) 
+    {
+        return false; // dummy will be removed by pr#314
+    }
     virtual void unlock(void) = 0;
 
     /**


### PR DESCRIPTION
Updated lock method to return false as a dummy implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timed SPI lock behavior by explicitly reporting when the lock is not acquired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->