### PR TITLE
fix: use external reference instead of duplicate SPI1

### DIFF
--- a/source/graphics/common/SdCard.cpp
+++ b/source/graphics/common/SdCard.cpp
@@ -208,11 +208,11 @@ bool SdFsCard::init(void)
 #else
 #if defined(SDCARD_USER_SPI_BEGIN)
     // fix : HSPI Does not have default pins on ESP32S3!
-    ILOG_INFO("SDHandler.begin(%d, %d, %d, %d)", SPI_SCK, SPI_MISO, SPI_MOSI, SDCARD_CS); delay(10);
+    ILOG_DEBUG("SDHandler.begin(%d, %d, %d, %d)", SPI_SCK, SPI_MISO, SPI_MOSI, SDCARD_CS);
     SDHandler.begin(SPI_SCK, SPI_MISO, SPI_MOSI, SDCARD_CS);
     return SDFs.begin(SdSpiConfig(SDCARD_CS, SHARED_SPI | USER_SPI_BEGIN, SD_SPI_FREQUENCY, &SDHandler));
 #else
-    ILOG_INFO("SDFs.begin(%d, %d, %d)", SDCARD_CS, SHARED_SPI, SD_SPI_FREQUENCY); delay(10);
+    ILOG_DEBUG("SDFs.begin(%d, %d, %d)", SDCARD_CS, SHARED_SPI, SD_SPI_FREQUENCY);
     return SDFs.begin(SdSpiConfig(SDCARD_CS, SHARED_SPI, SD_SPI_FREQUENCY, &SDHandler));
 #endif
 #endif

--- a/source/graphics/common/SdCard.cpp
+++ b/source/graphics/common/SdCard.cpp
@@ -12,8 +12,8 @@ fs::SDMMCFS &SDFs = SD_MMC;
 fs::FS &SDFs = PortduinoFS;
 #elif defined(HAS_SDCARD)
 #ifdef SDCARD_USE_SPI1
-static SPIClass SPI1(HSPI);
-static SPIClass &SDHandler = SPI1;
+extern SPIClass SPI_HSPI;
+static SPIClass &SDHandler = SPI_HSPI;
 #elif defined(SDCARD_USE_SOFT_SPI)
 static SoftSpiDriver<SPI_MISO, SPI_MOSI, SPI_SCK> SDHandler;
 #else
@@ -208,9 +208,11 @@ bool SdFsCard::init(void)
 #else
 #if defined(SDCARD_USER_SPI_BEGIN)
     // fix : HSPI Does not have default pins on ESP32S3!
+    ILOG_INFO("SDHandler.begin(%d, %d, %d, %d)", SPI_SCK, SPI_MISO, SPI_MOSI, SDCARD_CS); delay(10);
     SDHandler.begin(SPI_SCK, SPI_MISO, SPI_MOSI, SDCARD_CS);
     return SDFs.begin(SdSpiConfig(SDCARD_CS, SHARED_SPI | USER_SPI_BEGIN, SD_SPI_FREQUENCY, &SDHandler));
 #else
+    ILOG_INFO("SDFs.begin(%d, %d, %d)", SDCARD_CS, SHARED_SPI, SD_SPI_FREQUENCY); delay(10);
     return SDFs.begin(SdSpiConfig(SDCARD_CS, SHARED_SPI, SD_SPI_FREQUENCY, &SDHandler));
 #endif
 #endif


### PR DESCRIPTION
Use external allocated instance of SPI1 if `SDCARD_USE_SPI1`, proven to work with ThinkNodeM9 and T-Watch Ultra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD card initialization when using the secondary SPI interface.
  * Improved diagnostic messages during SD card setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->