### PR TITLE
fix: keyboard animation

### DIFF
--- a/include/graphics/view/TFT/TFTView_320x240.h
+++ b/include/graphics/view/TFT/TFTView_320x240.h
@@ -433,6 +433,7 @@ class TFTView_320x240 : public MeshtasticView
     static uint32_t pinKeys;                              // number of keys pressed (lock screen)
     static bool screenLocked;                             // screen lock active
     static bool screenUnlockRequest;                      // screen unlock request (via button)
+    static uint32_t kbdBtnPressTime;                      // true if keyboard animation is playing
     uint32_t selectedHops;                                // remember selected choice
     bool chooseNodeSignalScanner;                         // chose a target node for signal scanner
     bool chooseNodeTraceRoute;                            // chose a target node for trace route

--- a/include/graphics/view/TFT/TFTView_320x240.h
+++ b/include/graphics/view/TFT/TFTView_320x240.h
@@ -226,6 +226,8 @@ class TFTView_320x240 : public MeshtasticView
     void ui_set_active(lv_obj_t *b, lv_obj_t *p, lv_obj_t *tp);
     void showKeyboard(lv_obj_t *textArea);
     void hideKeyboard(lv_obj_t *panel);
+    // abort a running slide animation and restore panel/keyboard position at once
+    void resetKeyboardSlide(void);
     lv_obj_t *showQrCode(lv_obj_t *parent, const char *data);
 
     void enablePanel(lv_obj_t *panel);
@@ -433,7 +435,9 @@ class TFTView_320x240 : public MeshtasticView
     static uint32_t pinKeys;                              // number of keys pressed (lock screen)
     static bool screenLocked;                             // screen lock active
     static bool screenUnlockRequest;                      // screen unlock request (via button)
-    static uint32_t kbdBtnPressTime;                      // true if keyboard animation is playing
+    enum KbdSlide { eKbdHidden, eKbdSliding, eKbdShown };
+    static KbdSlide kbdSlideState;                        // slide state of the on-screen keyboard
+    static int32_t kbdPanelBaseY;                         // messages panel y at rest (INT32_MIN: not captured yet)
     uint32_t selectedHops;                                // remember selected choice
     bool chooseNodeSignalScanner;                         // chose a target node for signal scanner
     bool chooseNodeTraceRoute;                            // chose a target node for trace route

--- a/include/graphics/view/TFT/TFTView_320x240.h
+++ b/include/graphics/view/TFT/TFTView_320x240.h
@@ -409,32 +409,32 @@ class TFTView_320x240 : public MeshtasticView
 
     enum BasicSettings activeSettings = eNone; // active settings menu (used to disable other button presses)
 
-    static TFTView_320x240 *gui;                          // singleton pattern
-    bool screensInitialised;                              // true if init_screens is completed
-    uint32_t nodesFiltered;                               // no. hidden nodes in node list
-    bool nodesChanged;                                    // true if nodes changed (added or purged)
-    bool processingFilter;                                // indicates that filtering is ongoing
-    bool packetLogEnabled;                                // display received packets
-    bool detectorRunning;                                 // meshDetector is active
-    bool cardDetected;                                    // SD has been detected
-    bool formatSD;                                        // offer to format SD card
-    uint16_t buttonSize;                                  // size of group/chat buttons in pixels
-    uint16_t statisticTableRows;                          // number of rows in statistics table
-    uint16_t packetCounter;                               // number of packets in packet log
-    time_t lastrun60, lastrun10, lastrun5, lastrun1;      // timers for task loop
-    time_t actTime, uptime, lastHeard;                    // actual time and uptime; time last heard a node
-    bool hasPosition;                                     // if our position is known
-    int32_t myLatitude, myLongitude;                      // our current position as reported by firmware
-    void *topNodeLL;                                      // pointer to topmost button in group ll
-    uint32_t scans;                                       // scanner counter
-    lv_anim_t radar;                                      // radar animation
-    static uint32_t currentNode;                          // current selected node
-    static lv_obj_t *currentPanel;                        // current selected node panel
-    static lv_obj_t *spinnerButton;                       // start button animation
-    static time_t startTime;                              // time when start button was pressed
-    static uint32_t pinKeys;                              // number of keys pressed (lock screen)
-    static bool screenLocked;                             // screen lock active
-    static bool screenUnlockRequest;                      // screen unlock request (via button)
+    static TFTView_320x240 *gui;                     // singleton pattern
+    bool screensInitialised;                         // true if init_screens is completed
+    uint32_t nodesFiltered;                          // no. hidden nodes in node list
+    bool nodesChanged;                               // true if nodes changed (added or purged)
+    bool processingFilter;                           // indicates that filtering is ongoing
+    bool packetLogEnabled;                           // display received packets
+    bool detectorRunning;                            // meshDetector is active
+    bool cardDetected;                               // SD has been detected
+    bool formatSD;                                   // offer to format SD card
+    uint16_t buttonSize;                             // size of group/chat buttons in pixels
+    uint16_t statisticTableRows;                     // number of rows in statistics table
+    uint16_t packetCounter;                          // number of packets in packet log
+    time_t lastrun60, lastrun10, lastrun5, lastrun1; // timers for task loop
+    time_t actTime, uptime, lastHeard;               // actual time and uptime; time last heard a node
+    bool hasPosition;                                // if our position is known
+    int32_t myLatitude, myLongitude;                 // our current position as reported by firmware
+    void *topNodeLL;                                 // pointer to topmost button in group ll
+    uint32_t scans;                                  // scanner counter
+    lv_anim_t radar;                                 // radar animation
+    static uint32_t currentNode;                     // current selected node
+    static lv_obj_t *currentPanel;                   // current selected node panel
+    static lv_obj_t *spinnerButton;                  // start button animation
+    static time_t startTime;                         // time when start button was pressed
+    static uint32_t pinKeys;                         // number of keys pressed (lock screen)
+    static bool screenLocked;                        // screen lock active
+    static bool screenUnlockRequest;                 // screen unlock request (via button)
     enum KbdSlide { eKbdHidden, eKbdSliding, eKbdShown };
     static KbdSlide kbdSlideState;                        // slide state of the on-screen keyboard
     static int32_t kbdPanelBaseY;                         // messages panel y at rest (INT32_MIN: not captured yet)

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -123,7 +123,14 @@ time_t TFTView_320x240::startTime = 0;
 uint32_t TFTView_320x240::pinKeys = 0;
 bool TFTView_320x240::screenLocked = false;
 bool TFTView_320x240::screenUnlockRequest = false;
-uint32_t TFTView_320x240::kbdBtnPressTime = 0;
+TFTView_320x240::KbdSlide TFTView_320x240::kbdSlideState = TFTView_320x240::eKbdHidden;
+int32_t TFTView_320x240::kbdPanelBaseY = INT32_MIN;
+
+// file scope so a running slide can be targeted for deletion by exec callback
+static void kbdSlideAnimCB(void *var, int32_t v)
+{
+    lv_obj_set_y((lv_obj_t *)var, v);
+}
 
 TFTView_320x240 *TFTView_320x240::instance(void)
 {
@@ -474,9 +481,7 @@ void TFTView_320x240::ui_set_active(lv_obj_t *b, lv_obj_t *p, lv_obj_t *tp)
         lv_obj_add_flag(activePanel, LV_OBJ_FLAG_HIDDEN);
         if (activePanel == objects.messages_panel) {
             lv_obj_remove_state(objects.message_input_area, LV_STATE_FOCUSED);
-            if (!lv_obj_has_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN)) {
-                hideKeyboard(objects.messages_panel);
-            }
+            resetKeyboardSlide();
             uint32_t channelOrNode = (unsigned long)activeMsgContainer->user_data;
             // remove empty messageContainer if we are leaving messages panel
             if (channelOrNode >= c_max_channels) {
@@ -1604,10 +1609,10 @@ void TFTView_320x240::ui_event_KeyboardButton(lv_event_t *e)
         uint32_t keyBtnIdx = (unsigned long)e->user_data;
         switch (keyBtnIdx) {
         case 0:
-            if (lv_obj_has_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN)) {
+            if (kbdSlideState == eKbdHidden) {
                 lv_obj_remove_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
                 THIS->showKeyboard(objects.message_input_area);
-            } else {
+            } else if (kbdSlideState == eKbdShown) {
                 THIS->hideKeyboard(objects.messages_panel);
             }
             lv_group_focus_obj(objects.message_input_area);
@@ -1728,9 +1733,7 @@ void TFTView_320x240::ui_event_message_ready(lv_event_t *e)
             } else {
                 THIS->handleAddMessage(txt);
                 lv_textarea_set_text(objects.message_input_area, "");
-                if (!lv_obj_has_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN)) {
-                    THIS->hideKeyboard(objects.messages_panel);
-                }
+                THIS->hideKeyboard(objects.messages_panel);
                 lv_group_focus_obj(objects.message_input_area);
             }
         }
@@ -6915,38 +6918,34 @@ void TFTView_320x240::showKeyboard(lv_obj_t *textArea)
     uint32_t v = lv_display_get_vertical_resolution(displaydriver->getDisplay());
 
     if (textArea == objects.message_input_area) {
-        if (millis() - kbdBtnPressTime < 500) {
-            lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
+        if (kbdSlideState != eKbdHidden)
             return;
-        }
 
         // if keyboard is to be shown in message input area then scroll the panel using animation
-        static auto panelAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
-        static auto kbdAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
-        static auto deleted_cb = [](_lv_anim_t *) { kbdBtnPressTime = millis(); };
+        static auto shown_cb = [](_lv_anim_t *) { kbdSlideState = eKbdShown; };
 
         static lv_anim_t a1;
-        lv_area_t panel_coords;
-        lv_obj_get_coords(objects.messages_panel, &panel_coords);
+        int32_t panelY = lv_obj_get_y(objects.messages_panel);
+        if (kbdPanelBaseY == INT32_MIN)
+            kbdPanelBaseY = panelY;
 
-        kbdBtnPressTime = millis();
+        kbdSlideState = eKbdSliding;
         lv_anim_init(&a1);
         lv_anim_set_var(&a1, objects.messages_panel);
-        lv_anim_set_exec_cb(&a1, panelAnimCB);
-        lv_anim_set_values(&a1, panel_coords.y1, panel_coords.y1 - kb_h);
+        lv_anim_set_exec_cb(&a1, kbdSlideAnimCB);
+        lv_anim_set_values(&a1, panelY, kbdPanelBaseY - kb_h);
         lv_anim_set_duration(&a1, 300);
         lv_anim_set_path_cb(&a1, lv_anim_path_linear);
-        lv_anim_set_deleted_cb(&a1, deleted_cb);
         lv_anim_start(&a1);
 
         static lv_anim_t a2;
         lv_anim_init(&a2);
         lv_anim_set_var(&a2, objects.keyboard);
-        lv_anim_set_exec_cb(&a2, kbdAnimCB);
+        lv_anim_set_exec_cb(&a2, kbdSlideAnimCB);
         lv_anim_set_values(&a2, v, v - kb_h);
         lv_anim_set_duration(&a2, 300);
         lv_anim_set_path_cb(&a2, lv_anim_path_linear);
-        lv_anim_set_deleted_cb(&a2, deleted_cb);
+        lv_anim_set_deleted_cb(&a2, shown_cb);
         lv_anim_start(&a2);
     } else {
         if (text_coords.y1 > kb_h + 30) {
@@ -6968,27 +6967,24 @@ void TFTView_320x240::hideKeyboard(lv_obj_t *panel)
     lv_area_t kb_coords;
     lv_obj_get_coords(objects.keyboard, &kb_coords);
     uint32_t kb_h = kb_coords.y2 - kb_coords.y1;
+    uint32_t v = lv_display_get_vertical_resolution(displaydriver->getDisplay());
 
     if (panel == objects.messages_panel) {
-        if (millis() - kbdBtnPressTime < 500)
+        if (kbdSlideState != eKbdShown)
             return;
 
-        static auto panelAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
-        static auto kbdAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
         static auto deleted_cb = [](_lv_anim_t *) {
             lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
-            kbdBtnPressTime = millis();
+            kbdSlideState = eKbdHidden;
         };
 
         static lv_anim_t a1;
-        lv_area_t panel_coords;
-        lv_obj_get_coords(panel, &panel_coords);
 
-        kbdBtnPressTime = millis();
+        kbdSlideState = eKbdSliding;
         lv_anim_init(&a1);
         lv_anim_set_var(&a1, panel);
-        lv_anim_set_exec_cb(&a1, panelAnimCB);
-        lv_anim_set_values(&a1, panel_coords.y1, panel_coords.y1 + kb_h);
+        lv_anim_set_exec_cb(&a1, kbdSlideAnimCB);
+        lv_anim_set_values(&a1, lv_obj_get_y(panel), kbdPanelBaseY);
         lv_anim_set_duration(&a1, 300);
         lv_anim_set_path_cb(&a1, lv_anim_path_linear);
         lv_anim_start(&a1);
@@ -6996,13 +6992,28 @@ void TFTView_320x240::hideKeyboard(lv_obj_t *panel)
         static lv_anim_t a2;
         lv_anim_init(&a2);
         lv_anim_set_var(&a2, objects.keyboard);
-        lv_anim_set_exec_cb(&a2, kbdAnimCB);
-        lv_anim_set_values(&a2, kb_coords.y1, kb_coords.y1 + kb_h);
+        lv_anim_set_exec_cb(&a2, kbdSlideAnimCB);
+        lv_anim_set_values(&a2, lv_obj_get_y(objects.keyboard), v);
         lv_anim_set_duration(&a2, 300);
         lv_anim_set_path_cb(&a2, lv_anim_path_linear);
         lv_anim_set_deleted_cb(&a2, deleted_cb);
         lv_anim_start(&a2);
     }
+}
+
+/**
+ * @brief Put keyboard and message panel back to their rest position without animating,
+ *        e.g. when a menu button switches panels while a slide is still running.
+ */
+void TFTView_320x240::resetKeyboardSlide(void)
+{
+    lv_anim_delete(objects.messages_panel, kbdSlideAnimCB);
+    lv_anim_delete(objects.keyboard, kbdSlideAnimCB);
+    if (kbdPanelBaseY != INT32_MIN)
+        lv_obj_set_y(objects.messages_panel, kbdPanelBaseY);
+    lv_obj_set_y(objects.keyboard, lv_display_get_vertical_resolution(displaydriver->getDisplay()));
+    lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
+    kbdSlideState = eKbdHidden;
 }
 
 lv_obj_t *TFTView_320x240::showQrCode(lv_obj_t *parent, const char *data)

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -123,6 +123,7 @@ time_t TFTView_320x240::startTime = 0;
 uint32_t TFTView_320x240::pinKeys = 0;
 bool TFTView_320x240::screenLocked = false;
 bool TFTView_320x240::screenUnlockRequest = false;
+uint32_t TFTView_320x240::kbdBtnPressTime = 0;
 
 TFTView_320x240 *TFTView_320x240::instance(void)
 {
@@ -4475,8 +4476,7 @@ void TFTView_320x240::ui_event_frequency_slot_slider(lv_event_t *e)
 void TFTView_320x240::ui_event_modem_preset_dropdown(lv_event_t *e)
 {
     lv_obj_t *dropdown = lv_event_get_target_obj(e);
-    meshtastic_Config_LoRaConfig_ModemPreset preset =
-        THIS->val2preset((meshtastic_Config_LoRaConfig_ModemPreset)lv_dropdown_get_selected(dropdown));
+    meshtastic_Config_LoRaConfig_ModemPreset preset = THIS->val2preset(lv_dropdown_get_selected(dropdown));
     uint32_t numChannels = LoRaPresets::getNumChannels(THIS->db.config.lora.region, preset);
     if (numChannels == 0) {
         // preset not possible for this region, revert
@@ -6915,20 +6915,28 @@ void TFTView_320x240::showKeyboard(lv_obj_t *textArea)
     uint32_t v = lv_display_get_vertical_resolution(displaydriver->getDisplay());
 
     if (textArea == objects.message_input_area) {
+        if (millis() - kbdBtnPressTime < 500) {
+            lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
+            return;
+        }
+
         // if keyboard is to be shown in message input area then scroll the panel using animation
         static auto panelAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
         static auto kbdAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
+        static auto deleted_cb = [](_lv_anim_t *) { kbdBtnPressTime = millis(); };
 
         static lv_anim_t a1;
         lv_area_t panel_coords;
         lv_obj_get_coords(objects.messages_panel, &panel_coords);
 
+        kbdBtnPressTime = millis();
         lv_anim_init(&a1);
         lv_anim_set_var(&a1, objects.messages_panel);
         lv_anim_set_exec_cb(&a1, panelAnimCB);
         lv_anim_set_values(&a1, panel_coords.y1, panel_coords.y1 - kb_h);
         lv_anim_set_duration(&a1, 300);
         lv_anim_set_path_cb(&a1, lv_anim_path_linear);
+        lv_anim_set_deleted_cb(&a1, deleted_cb);
         lv_anim_start(&a1);
 
         static lv_anim_t a2;
@@ -6938,6 +6946,7 @@ void TFTView_320x240::showKeyboard(lv_obj_t *textArea)
         lv_anim_set_values(&a2, v, v - kb_h);
         lv_anim_set_duration(&a2, 300);
         lv_anim_set_path_cb(&a2, lv_anim_path_linear);
+        lv_anim_set_deleted_cb(&a2, deleted_cb);
         lv_anim_start(&a2);
     } else {
         if (text_coords.y1 > kb_h + 30) {
@@ -6961,14 +6970,21 @@ void TFTView_320x240::hideKeyboard(lv_obj_t *panel)
     uint32_t kb_h = kb_coords.y2 - kb_coords.y1;
 
     if (panel == objects.messages_panel) {
+        if (millis() - kbdBtnPressTime < 500)
+            return;
+
         static auto panelAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
         static auto kbdAnimCB = [](void *var, int32_t v) { lv_obj_set_y((lv_obj_t *)var, v); };
-        static auto deleted_cb = [](_lv_anim_t *) { lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN); };
+        static auto deleted_cb = [](_lv_anim_t *) {
+            lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
+            kbdBtnPressTime = millis();
+        };
 
         static lv_anim_t a1;
         lv_area_t panel_coords;
         lv_obj_get_coords(panel, &panel_coords);
 
+        kbdBtnPressTime = millis();
         lv_anim_init(&a1);
         lv_anim_set_var(&a1, panel);
         lv_anim_set_exec_cb(&a1, panelAnimCB);


### PR DESCRIPTION
By toggling the keyboard button quickly (hide twice) it was possible to let scroll the keyboard out of sight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved on-screen keyboard show and hide transitions.
  - Prevented overlapping or interrupted keyboard animations when switching panels.
  - Restored the messages panel and keyboard to the correct position when transitions are interrupted.
  - Improved keyboard behavior when submitting messages or changing panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->