### PR TITLE
fix: removal of saved map style on SD leads to url not found

### DIFF
--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2695,6 +2695,8 @@ void TFTView_320x240::loadMap(void)
             } else if (!mapStyles.empty()) {
                 // populate style dropdown
                 bool savedStyleOK = false;
+                int firstUrlEntry = -1;
+                std::string firstUrl;
                 lv_dropdown_clear_options(objects.map_style_dropdown);
                 for (auto it : mapStyles) {
                     // add url provider if exist
@@ -2703,6 +2705,10 @@ void TFTView_320x240::loadMap(void)
                     if (!url.empty()) {
                         urlEntry = TileProvider::addTemplate("URL: " + it, url);
                         lv_dropdown_add_option(objects.map_url_dropdown, std::string("URL: " + it).c_str(), LV_DROPDOWN_POS_LAST);
+                    }
+                    if (it == *mapStyles.begin()) {
+                        firstUrlEntry = urlEntry;
+                        firstUrl = url;
                     }
                     lv_dropdown_add_option(objects.map_style_dropdown, it.c_str(), LV_DROPDOWN_POS_LAST);
                     if (it == db.uiConfig.map_data.style) {
@@ -2730,6 +2736,12 @@ void TFTView_320x240::loadMap(void)
                     lv_dropdown_set_selected(objects.map_style_dropdown, 0);
                     lv_dropdown_get_selected_str(objects.map_style_dropdown, style, sizeof(style));
                     MapTileSettings::setTileStyle(style);
+                    // this fallback style also needs its URL template registered, else fetch silently no-ops
+                    if (firstUrlEntry >= 0) {
+                        ILOG_DEBUG("set provider url to %s", style);
+                        TileProvider::selectTemplate(firstUrlEntry);
+                        attribution(firstUrl);
+                    }
                 }
 
                 MapTileSettings::setSaveOK(savedStyleOK); // allow SD save only for identical style

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2740,6 +2740,7 @@ void TFTView_320x240::loadMap(void)
                     if (firstUrlEntry >= 0) {
                         ILOG_DEBUG("set provider url to %s", style);
                         TileProvider::selectTemplate(firstUrlEntry);
+                        lv_dropdown_set_selected(objects.map_url_dropdown, firstUrlEntry);
                         attribution(firstUrl);
                     }
                 }


### PR DESCRIPTION
fixes the path where the first map style is selected when the saved style is not found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed map display when the previously selected style is unavailable on the SD card.
  * The first available map style is now used correctly, including its tile source, synchronized URL selection, and attribution information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->