### PR TITLE
feat: add NM CYD C5 (standalone-ui)

### DIFF
--- a/include/graphics/LGFX/LGFXConfig.h
+++ b/include/graphics/LGFX/LGFXConfig.h
@@ -90,7 +90,7 @@ class LGFXConfig : public lgfx::LGFX_Device
         }
 
         { // configure bus settings
-#ifndef ARCH_PORTDUINO
+#if !defined(ARCH_PORTDUINO) && !defined(CONFIG_IDF_TARGET_ESP32C5) && !CONFIG_IDF_TARGET_ESP32C5
             if (config._bus.parallel.pin_d0 > 0) {
                 lgfx::Bus_Parallel8 *bus = new lgfx::Bus_Parallel8;
                 auto cfg = bus->config();

--- a/include/graphics/LGFX/LGFX_ESP_NM_CYD_C5.h
+++ b/include/graphics/LGFX/LGFX_ESP_NM_CYD_C5.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#define LGFX_USE_V1
+#include <LovyanGFX.hpp>
+
+#ifndef SPI_FREQUENCY
+#define SPI_FREQUENCY 20000000
+#endif
+#ifndef HSPI_HOST
+#define HSPI_HOST 0
+#endif
+#ifndef VSPI_HOST
+#define VSPI_HOST 1
+#endif
+
+class LGFX_ESP_NM_CYD_C5 : public lgfx::LGFX_Device
+{
+    lgfx::Panel_ST7789 _panel_instance;
+    lgfx::Bus_SPI _bus_instance;
+    lgfx::Light_PWM _light_instance;
+    lgfx::Touch_XPT2046 _touch_instance;
+
+  public:
+    const uint32_t screenWidth = 320;
+    const uint32_t screenHeight = 240;
+
+    bool hasButton(void) { return true; }
+
+    LGFX_ESP_NM_CYD_C5(void)
+    {
+        {
+            auto cfg = _bus_instance.config();
+
+            // SPI
+            cfg.spi_host = SPI2_HOST;
+            cfg.spi_mode = 0;
+            cfg.freq_write = SPI_FREQUENCY; // SPI clock for transmission (up to 80MHz, rounded to
+                                            // the value obtained by dividing 80MHz by an integer)
+            cfg.freq_read = 20000000;       // SPI clock when receiving
+            cfg.spi_3wire = false;
+            cfg.use_lock = false;              // Set to true to use transaction locking
+            cfg.dma_channel = SPI_DMA_CH_AUTO; // SPI_DMA_CH_AUTO; // Set DMA channel
+                                               // to use (0=not use DMA / 1=1ch / 2=ch
+                                               // / SPI_DMA_CH_AUTO=auto setting)
+            cfg.pin_sclk = 6;                  // Set SPI SCLK pin number
+            cfg.pin_mosi = 7;                  // Set SPI MOSI pin number
+            cfg.pin_miso = 2;                  // Set SPI MISO pin number (-1 = disable)
+            cfg.pin_dc = 24;                   // Set SPI DC pin number (-1 = disable)
+
+            _bus_instance.config(cfg);              // applies the set value to the bus.
+            _panel_instance.setBus(&_bus_instance); // set the bus on the panel.
+        }
+
+        {                                        // Set the display panel control.
+            auto cfg = _panel_instance.config(); // Gets a structure for display panel settings.
+
+            cfg.pin_cs = 23;   // Pin number where CS is connected (-1 = disable)
+            cfg.pin_rst = -1;  // Pin number where RST is connected  (-1 = disable)
+            cfg.pin_busy = -1; // Pin number where BUSY is connected (-1 = disable)
+
+            // The following setting values ​​are general initial values ​​for
+            // each panel, so please comment out any unknown items and try them.
+
+            cfg.panel_width = screenHeight; // actual displayable width
+            cfg.panel_height = screenWidth; // actual displayable height
+            cfg.offset_x = 0;               // Panel offset amount in X direction
+            cfg.offset_y = 0;               // Panel offset amount in Y direction
+            cfg.offset_rotation = 1;        // Rotation direction value offset 0~7 (4~7 is upside down)
+            cfg.dummy_read_pixel = 8;       // Number of bits for dummy read before pixel readout
+            cfg.dummy_read_bits = 1;        // Number of bits for dummy read before non-pixel data read
+            cfg.readable = true;            // Set to true if data can be read
+            cfg.invert = false;             // Set to true if the light/darkness of the panel is reversed
+            cfg.rgb_order = false;          // Set to true if the panel's red and blue are swapped
+            cfg.dlen_16bit = false;         // Set to true for panels that transmit data length in 16-bit
+                                            // units with 16-bit parallel or SPI
+            cfg.bus_shared = true;          // If the bus is shared with the SD card, set to
+                                            // true (bus control with drawJpgFile etc.)
+
+            // Set the following only when the display is shifted with a driver with a
+            // variable number of pixels, such as the ST7735 or ILI9163.
+            // cfg.memory_width = TFT_WIDTH;   // Maximum width supported by the
+            // driver IC cfg.memory_height = TFT_HEIGHT;  // Maximum height supported
+            // by the driver IC
+            _panel_instance.config(cfg);
+        }
+
+        // Set the backlight control. (delete if not necessary)
+        {
+            auto cfg = _light_instance.config(); // Gets a structure for backlight settings.
+
+            cfg.pin_bl = 25;    // Pin number to which the backlight is connected
+            cfg.invert = false; // true to invert the brightness of the backlight
+            cfg.freq = 44100;
+            cfg.pwm_channel = 7;
+
+            _light_instance.config(cfg);
+            _panel_instance.setLight(&_light_instance); // Set the backlight on the panel.
+        }
+
+        // Configure settings for touch screen control.
+        {
+            auto cfg = _touch_instance.config();
+
+            cfg.freq = 2500000;
+            cfg.x_min = 3850;
+            cfg.x_max = 200;
+            cfg.y_min = 200;
+            cfg.y_max = 3850;
+            cfg.pin_int = -1;
+            cfg.pin_rst = -1;
+            cfg.offset_rotation = 0;
+            cfg.bus_shared = true;
+
+            // SPI
+            cfg.spi_host = SPI2_HOST;
+            cfg.pin_sclk = 6;
+            cfg.pin_miso = 2;
+            cfg.pin_mosi = 7;
+            cfg.pin_cs = 1;
+
+            _touch_instance.config(cfg);
+            _panel_instance.setTouch(&_touch_instance);
+        }
+
+        setPanel(&_panel_instance); // Sets the panel to use.
+    }
+};

--- a/include/graphics/driver/DisplayDriverConfig.h
+++ b/include/graphics/driver/DisplayDriverConfig.h
@@ -41,7 +41,8 @@ class DisplayDriverConfig
         ESP4848S040,
         MAKERFABS480X480,
         HELTECV4_TFT,
-        WIO_TRACKER_L2
+        WIO_TRACKER_L2,
+        NM_CYD_C5
     };
 
     struct panel_config_t {

--- a/include/graphics/driver/LGFXDriver.h
+++ b/include/graphics/driver/LGFXDriver.h
@@ -400,6 +400,8 @@ template <class LGFX> void LGFXDriver<LGFX>::init_lgfx(void)
         uint16_t parameters[8] = {255, 3691, 203, 198, 3836, 3659, 3795, 162};
 #elif defined(SENSECAP_INDICATOR)
         uint16_t parameters[8] = {23, 3, 0, 479, 476, 2, 475, 479};
+#elif defined(ESP32_NM_CYD_C5)
+        uint16_t parameters[8] = {3787, 226, 3857, 3833, 309, 238, 309, 3803};
 #else
         uint16_t parameters[8] = {0, 0, 0, 319, 239, 0, 239, 319};
         ILOG_WARN("Touch screen has no calibration data!!!");

--- a/source/graphics/common/LoRaPresets.cpp
+++ b/source/graphics/common/LoRaPresets.cpp
@@ -1,6 +1,7 @@
 #include "graphics/common/LoRaPresets.h"
 #include "lv_i18n.h"
 #include "util/ILog.h"
+#include <iterator>
 
 /**
  * LoRa Presets

--- a/source/graphics/driver/DisplayDriverFactory.cpp
+++ b/source/graphics/driver/DisplayDriverFactory.cpp
@@ -57,6 +57,9 @@
 #ifdef ESP32_2432S022
 #include "graphics/LGFX/LGFX_ESP2432S022.h"
 #endif
+#ifdef ESP32_NM_CYD_C5
+#include "graphics/LGFX/LGFX_ESP_NM_CYD_C5.h"
+#endif
 #ifdef ESP32_2432S028RV1
 #include "graphics/LGFX/LGFX_ESP2432S028RV1.h"
 #endif
@@ -191,6 +194,10 @@ DisplayDriver *DisplayDriverFactory::create(const DisplayDriverConfig &cfg)
 #elif defined(WT_SC01_PLUS)
     case DisplayDriverConfig::device_t::WT32_SC01_PLUS:
         return new LGFXDriver<LGFX_WT_SC01_PLUS>(cfg.width(), cfg.height());
+        break;
+#elif defined(ESP32_NM_CYD_C5)
+    case DisplayDriverConfig::device_t::NM_CYD_C5:
+        return new LGFXDriver<LGFX_ESP_NM_CYD_C5>(cfg.width(), cfg.height());
         break;
 #elif defined(ESP2432S028RV1)
     case DisplayDriverConfig::device_t::ESP2432S028RV1:


### PR DESCRIPTION
<img width="3000" height="2000" alt="image" src="https://github.com/user-attachments/assets/8493ad99-0ef2-4b88-8f3e-2a17ecc84a24" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display support for the ESP32 NM-CYD-C5 board.
  - Added a 320×240 SPI display configuration with touch input, PWM backlight, and button detection.
  - Added board-specific touch calibration for improved touchscreen accuracy.
  - Added NM-CYD-C5 as a selectable display device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->