### PR TITLE
fix: support strict macOS clang builds

### DIFF
--- a/source/comms/serial/SerialClient.cpp
+++ b/source/comms/serial/SerialClient.cpp
@@ -40,9 +40,9 @@ void SerialClient::init(void)
 #if defined(HAS_FREE_RTOS) || defined(ARCH_ESP32)
     xTaskCreateUniversal(task_loop, threadName, 8192, NULL, 1, NULL, 0);
 #elif defined(ARCH_PORTDUINO)
-    new std::thread([] {
+    new std::thread([this] {
 #ifdef __APPLE__
-        pthread_setname_np(threadName);
+        pthread_setname_np(this->threadName);
 #else
         pthread_setname_np(pthread_self(), instance->threadName);
 #endif

--- a/source/graphics/common/MeshtasticView.cpp
+++ b/source/graphics/common/MeshtasticView.cpp
@@ -214,7 +214,7 @@ bool MeshtasticView::base64ToPsk(const std::string &base64, uint8_t *bytes, uint
     std::string out;
     auto error = macaron::Base64::Decode(base64, out);
     if (!error.empty()) {
-        ILOG_ERROR("Cannot decode '%s'", base64);
+        ILOG_ERROR("Cannot decode '%s'", base64.c_str());
         return false;
     } else {
         memcpy((char *)bytes, out.data(), out.size());


### PR DESCRIPTION
Summary
- Capture the Portduino client when naming its thread on Darwin.
- Pass a C string to the printf-style decode-error logger.

Why
- Apple Clang rejects the uncaptured member access and the non-POD variadic argument; Linux accepted both paths.

Validation
- `trunk fmt source/comms/serial/SerialClient.cpp source/graphics/common/MeshtasticView.cpp`
- Integrated `pio run -e native-macos-tft` completed successfully with Apple Clang after these fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread naming on Apple-based serial platforms.
  * Corrected diagnostic logging for Base64 decoding errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->