### PR TITLE
feat: Edit URL templates

### DIFF
--- a/generated/ui_240x320/screens.c
+++ b/generated/ui_240x320/screens.c
@@ -1692,9 +1692,11 @@ void create_screen_main_screen() {
                     // mapOSDPanel
                     lv_obj_t *obj = lv_obj_create(parent_obj);
                     objects.map_osd_panel = obj;
-                    lv_obj_set_pos(obj, 10, 5);
-                    lv_obj_set_size(obj, LV_PCT(80), 180);
+                    lv_obj_set_pos(obj, 1, 5);
+                    lv_obj_set_size(obj, LV_PCT(90), 180);
                     lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+                    lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
+                    lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
                     lv_obj_set_style_bg_color(obj, lv_color_hex(0x101010), LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -1712,8 +1714,8 @@ void create_screen_main_screen() {
                             // mapBrightnessSlider
                             lv_obj_t *obj = lv_slider_create(parent_obj);
                             objects.map_brightness_slider = obj;
-                            lv_obj_set_pos(obj, 0, 10);
-                            lv_obj_set_size(obj, LV_PCT(85), 8);
+                            lv_obj_set_pos(obj, -5, 15);
+                            lv_obj_set_size(obj, LV_PCT(80), 8);
                             lv_slider_set_range(obj, 0, 255);
                             lv_slider_set_value(obj, 200, LV_ANIM_OFF);
                             lv_obj_remove_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_ON_FOCUS|LV_OBJ_FLAG_SCROLL_WITH_ARROW);
@@ -1732,8 +1734,8 @@ void create_screen_main_screen() {
                             // mapContrastSlider
                             lv_obj_t *obj = lv_slider_create(parent_obj);
                             objects.map_contrast_slider = obj;
-                            lv_obj_set_pos(obj, 0, 36);
-                            lv_obj_set_size(obj, LV_PCT(85), 8);
+                            lv_obj_set_pos(obj, -5, 40);
+                            lv_obj_set_size(obj, LV_PCT(80), 8);
                             lv_slider_set_range(obj, 30, 255);
                             lv_slider_set_value(obj, 200, LV_ANIM_OFF);
                             lv_obj_remove_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_ON_FOCUS|LV_OBJ_FLAG_SCROLL_WITH_ARROW);
@@ -1752,8 +1754,8 @@ void create_screen_main_screen() {
                             // mapStyleDropdown
                             lv_obj_t *obj = lv_dropdown_create(parent_obj);
                             objects.map_style_dropdown = obj;
-                            lv_obj_set_pos(obj, 0, 58);
-                            lv_obj_set_size(obj, LV_PCT(85), LV_SIZE_CONTENT);
+                            lv_obj_set_pos(obj, -5, 70);
+                            lv_obj_set_size(obj, LV_PCT(80), LV_SIZE_CONTENT);
                             lv_dropdown_set_options(obj, _("map tiles not found!"));
                             lv_dropdown_set_selected(obj, 0);
                             add_style_drop_down_style(obj);
@@ -1768,9 +1770,9 @@ void create_screen_main_screen() {
                             // mapUrlDropdown
                             lv_obj_t *obj = lv_dropdown_create(parent_obj);
                             objects.map_url_dropdown = obj;
-                            lv_obj_set_pos(obj, 0, 92);
-                            lv_obj_set_size(obj, LV_PCT(85), LV_SIZE_CONTENT);
-                            lv_dropdown_set_options(obj, _("Google Maps"));
+                            lv_obj_set_pos(obj, -5, 108);
+                            lv_obj_set_size(obj, LV_PCT(80), LV_SIZE_CONTENT);
+                            lv_dropdown_set_options(obj, _(""));
                             lv_dropdown_set_selected(obj, 0);
                             add_style_drop_down_style(obj);
                             lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -1779,6 +1781,38 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_left(obj, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_row(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_column(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+                        }
+                        {
+                            // mapUrlTextarea
+                            lv_obj_t *obj = lv_textarea_create(parent_obj);
+                            objects.map_url_textarea = obj;
+                            lv_obj_set_pos(obj, -5, 108);
+                            lv_obj_set_size(obj, LV_PCT(80), 27);
+                            lv_textarea_set_max_length(obj, 80);
+                            lv_textarea_set_placeholder_text(obj, "Enter URL template");
+                            lv_textarea_set_one_line(obj, true);
+                            lv_textarea_set_password_mode(obj, false);
+                            lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+                            lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
+                            lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_max_height(obj, 25, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_left(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+                        }
+                        {
+                            // KeyboardButton_12
+                            lv_obj_t *obj = lv_button_create(parent_obj);
+                            objects.keyboard_button_12 = obj;
+                            lv_obj_set_pos(obj, 190, 108);
+                            lv_obj_set_size(obj, 25, 25);
+                            lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+                            lv_obj_set_style_align(obj, LV_ALIGN_DEFAULT, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_color(obj, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_image_src(obj, &img_keyboard_image, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_image_recolor(obj, lv_color_hex(0x373737), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_image_recolor_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
                 }
@@ -3431,7 +3465,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 248);
+                    create_user_widget_ok_cancel_widget(obj, 250);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3743,7 +3777,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 269);
+                    create_user_widget_ok_cancel_widget(obj, 271);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3789,7 +3823,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 275);
+                    create_user_widget_ok_cancel_widget(obj, 277);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3868,7 +3902,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 283);
+                    create_user_widget_ok_cancel_widget(obj, 285);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3915,7 +3949,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 289);
+                    create_user_widget_ok_cancel_widget(obj, 291);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4026,7 +4060,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 298);
+                    create_user_widget_ok_cancel_widget(obj, 300);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4090,7 +4124,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 305);
+                    create_user_widget_ok_cancel_widget(obj, 307);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4136,7 +4170,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 311);
+                    create_user_widget_ok_cancel_widget(obj, 313);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4201,7 +4235,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 318);
+                    create_user_widget_ok_cancel_widget(obj, 320);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4307,7 +4341,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 326);
+                    create_user_widget_ok_cancel_widget(obj, 328);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -4394,7 +4428,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 334);
+                    create_user_widget_ok_cancel_widget(obj, 336);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4470,7 +4504,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 341);
+                    create_user_widget_ok_cancel_widget(obj, 343);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4516,7 +4550,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 347);
+                    create_user_widget_ok_cancel_widget(obj, 349);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4593,7 +4627,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 354);
+                    create_user_widget_ok_cancel_widget(obj, 356);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4623,7 +4657,7 @@ void create_screen_main_screen() {
                     objects.settings_backup_checkbox = obj;
                     lv_obj_set_pos(obj, 5, -1);
                     lv_obj_set_size(obj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-                    lv_checkbox_set_text_static(obj, _("Backup"));
+                    lv_checkbox_set_text(obj, _("Backup"));
                     lv_obj_set_style_bg_color(obj, lv_color_hex(0x67ea94), LV_PART_INDICATOR | LV_STATE_CHECKED);
                 }
                 {
@@ -4632,7 +4666,7 @@ void create_screen_main_screen() {
                     objects.settings_restore_checkbox = obj;
                     lv_obj_set_pos(obj, 5, 25);
                     lv_obj_set_size(obj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-                    lv_checkbox_set_text_static(obj, _("Restore"));
+                    lv_checkbox_set_text(obj, _("Restore"));
                     lv_obj_set_style_bg_color(obj, lv_color_hex(0x67ea94), LV_PART_INDICATOR | LV_STATE_CHECKED);
                 }
                 {
@@ -4659,7 +4693,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 362);
+                    create_user_widget_ok_cancel_widget(obj, 364);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4704,7 +4738,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 368);
+                    create_user_widget_ok_cancel_widget(obj, 370);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4849,7 +4883,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 381);
+                    create_user_widget_ok_cancel_widget(obj, 383);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -6548,7 +6582,7 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            create_user_widget_ok_cancel_widget(obj, 488);
+                            create_user_widget_ok_cancel_widget(obj, 490);
                             lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
@@ -6610,24 +6644,24 @@ void create_screen_main_screen() {
 }
 
 void tick_screen_main_screen() {
-    tick_user_widget_ok_cancel_widget(248);
-    tick_user_widget_ok_cancel_widget(269);
-    tick_user_widget_ok_cancel_widget(275);
-    tick_user_widget_ok_cancel_widget(283);
-    tick_user_widget_ok_cancel_widget(289);
-    tick_user_widget_ok_cancel_widget(298);
-    tick_user_widget_ok_cancel_widget(305);
-    tick_user_widget_ok_cancel_widget(311);
-    tick_user_widget_ok_cancel_widget(318);
-    tick_user_widget_ok_cancel_widget(326);
-    tick_user_widget_ok_cancel_widget(334);
-    tick_user_widget_ok_cancel_widget(341);
-    tick_user_widget_ok_cancel_widget(347);
-    tick_user_widget_ok_cancel_widget(354);
-    tick_user_widget_ok_cancel_widget(362);
-    tick_user_widget_ok_cancel_widget(368);
-    tick_user_widget_ok_cancel_widget(381);
-    tick_user_widget_ok_cancel_widget(488);
+    tick_user_widget_ok_cancel_widget(250);
+    tick_user_widget_ok_cancel_widget(271);
+    tick_user_widget_ok_cancel_widget(277);
+    tick_user_widget_ok_cancel_widget(285);
+    tick_user_widget_ok_cancel_widget(291);
+    tick_user_widget_ok_cancel_widget(300);
+    tick_user_widget_ok_cancel_widget(307);
+    tick_user_widget_ok_cancel_widget(313);
+    tick_user_widget_ok_cancel_widget(320);
+    tick_user_widget_ok_cancel_widget(328);
+    tick_user_widget_ok_cancel_widget(336);
+    tick_user_widget_ok_cancel_widget(343);
+    tick_user_widget_ok_cancel_widget(349);
+    tick_user_widget_ok_cancel_widget(356);
+    tick_user_widget_ok_cancel_widget(364);
+    tick_user_widget_ok_cancel_widget(370);
+    tick_user_widget_ok_cancel_widget(383);
+    tick_user_widget_ok_cancel_widget(490);
 }
 
 void create_user_widget_ok_cancel_widget(lv_obj_t *parent_obj, int startWidgetIndex) {

--- a/generated/ui_240x320/screens.c
+++ b/generated/ui_240x320/screens.c
@@ -1783,36 +1783,54 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_column(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                         {
-                            // mapUrlTextarea
-                            lv_obj_t *obj = lv_textarea_create(parent_obj);
-                            objects.map_url_textarea = obj;
-                            lv_obj_set_pos(obj, -5, 108);
-                            lv_obj_set_size(obj, LV_PCT(80), 27);
-                            lv_textarea_set_max_length(obj, 80);
-                            lv_textarea_set_placeholder_text(obj, "Enter URL template");
-                            lv_textarea_set_one_line(obj, true);
-                            lv_textarea_set_password_mode(obj, false);
+                            // mapUrlPanel
+                            lv_obj_t *obj = lv_obj_create(parent_obj);
+                            objects.map_url_panel = obj;
+                            lv_obj_set_pos(obj, 5, 108);
+                            lv_obj_set_size(obj, LV_PCT(90), 27);
                             lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
-                            lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
+                            lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
                             lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_max_height(obj, 25, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_pad_left(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
-                        }
-                        {
-                            // KeyboardButton_12
-                            lv_obj_t *obj = lv_button_create(parent_obj);
-                            objects.keyboard_button_12 = obj;
-                            lv_obj_set_pos(obj, 190, 108);
-                            lv_obj_set_size(obj, 25, 25);
-                            lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
-                            lv_obj_set_style_align(obj, LV_ALIGN_DEFAULT, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_color(obj, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_image_src(obj, &img_keyboard_image, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_image_recolor(obj, lv_color_hex(0x373737), LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_image_recolor_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_left(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_right(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            {
+                                lv_obj_t *parent_obj = obj;
+                                {
+                                    // mapUrlTextarea
+                                    lv_obj_t *obj = lv_textarea_create(parent_obj);
+                                    objects.map_url_textarea = obj;
+                                    lv_obj_set_pos(obj, 0, 0);
+                                    lv_obj_set_size(obj, LV_PCT(86), 27);
+                                    lv_textarea_set_max_length(obj, 80);
+                                    lv_textarea_set_placeholder_text(obj, "Enter URL template");
+                                    lv_textarea_set_one_line(obj, true);
+                                    lv_textarea_set_password_mode(obj, false);
+                                    lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
+                                    lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_align(obj, LV_ALIGN_LEFT_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_max_height(obj, 25, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_pad_left(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_pad_right(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                }
+                                {
+                                    // KeyboardButton_12
+                                    lv_obj_t *obj = lv_button_create(parent_obj);
+                                    objects.keyboard_button_12 = obj;
+                                    lv_obj_set_pos(obj, 0, 0);
+                                    lv_obj_set_size(obj, 25, 25);
+                                    lv_obj_set_style_bg_color(obj, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_bg_image_src(obj, &img_keyboard_image, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_bg_image_recolor(obj, lv_color_hex(0x373737), LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_bg_image_recolor_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_align(obj, LV_ALIGN_RIGHT_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                }
+                            }
                         }
                     }
                 }
@@ -3465,7 +3483,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 250);
+                    create_user_widget_ok_cancel_widget(obj, 251);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3777,7 +3795,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 271);
+                    create_user_widget_ok_cancel_widget(obj, 272);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3823,7 +3841,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 277);
+                    create_user_widget_ok_cancel_widget(obj, 278);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3902,7 +3920,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 285);
+                    create_user_widget_ok_cancel_widget(obj, 286);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3949,7 +3967,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 291);
+                    create_user_widget_ok_cancel_widget(obj, 292);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4060,7 +4078,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 300);
+                    create_user_widget_ok_cancel_widget(obj, 301);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4124,7 +4142,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 307);
+                    create_user_widget_ok_cancel_widget(obj, 308);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4170,7 +4188,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 313);
+                    create_user_widget_ok_cancel_widget(obj, 314);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4235,7 +4253,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 320);
+                    create_user_widget_ok_cancel_widget(obj, 321);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4341,7 +4359,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 328);
+                    create_user_widget_ok_cancel_widget(obj, 329);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -4428,7 +4446,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 336);
+                    create_user_widget_ok_cancel_widget(obj, 337);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4504,7 +4522,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 343);
+                    create_user_widget_ok_cancel_widget(obj, 344);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4550,7 +4568,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 349);
+                    create_user_widget_ok_cancel_widget(obj, 350);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4627,7 +4645,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 356);
+                    create_user_widget_ok_cancel_widget(obj, 357);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4693,7 +4711,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 364);
+                    create_user_widget_ok_cancel_widget(obj, 365);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4738,7 +4756,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 370);
+                    create_user_widget_ok_cancel_widget(obj, 371);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4883,7 +4901,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 383);
+                    create_user_widget_ok_cancel_widget(obj, 384);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -6582,7 +6600,7 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            create_user_widget_ok_cancel_widget(obj, 490);
+                            create_user_widget_ok_cancel_widget(obj, 491);
                             lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
@@ -6644,24 +6662,24 @@ void create_screen_main_screen() {
 }
 
 void tick_screen_main_screen() {
-    tick_user_widget_ok_cancel_widget(250);
-    tick_user_widget_ok_cancel_widget(271);
-    tick_user_widget_ok_cancel_widget(277);
-    tick_user_widget_ok_cancel_widget(285);
-    tick_user_widget_ok_cancel_widget(291);
-    tick_user_widget_ok_cancel_widget(300);
-    tick_user_widget_ok_cancel_widget(307);
-    tick_user_widget_ok_cancel_widget(313);
-    tick_user_widget_ok_cancel_widget(320);
-    tick_user_widget_ok_cancel_widget(328);
-    tick_user_widget_ok_cancel_widget(336);
-    tick_user_widget_ok_cancel_widget(343);
-    tick_user_widget_ok_cancel_widget(349);
-    tick_user_widget_ok_cancel_widget(356);
-    tick_user_widget_ok_cancel_widget(364);
-    tick_user_widget_ok_cancel_widget(370);
-    tick_user_widget_ok_cancel_widget(383);
-    tick_user_widget_ok_cancel_widget(490);
+    tick_user_widget_ok_cancel_widget(251);
+    tick_user_widget_ok_cancel_widget(272);
+    tick_user_widget_ok_cancel_widget(278);
+    tick_user_widget_ok_cancel_widget(286);
+    tick_user_widget_ok_cancel_widget(292);
+    tick_user_widget_ok_cancel_widget(301);
+    tick_user_widget_ok_cancel_widget(308);
+    tick_user_widget_ok_cancel_widget(314);
+    tick_user_widget_ok_cancel_widget(321);
+    tick_user_widget_ok_cancel_widget(329);
+    tick_user_widget_ok_cancel_widget(337);
+    tick_user_widget_ok_cancel_widget(344);
+    tick_user_widget_ok_cancel_widget(350);
+    tick_user_widget_ok_cancel_widget(357);
+    tick_user_widget_ok_cancel_widget(365);
+    tick_user_widget_ok_cancel_widget(371);
+    tick_user_widget_ok_cancel_widget(384);
+    tick_user_widget_ok_cancel_widget(491);
 }
 
 void create_user_widget_ok_cancel_widget(lv_obj_t *parent_obj, int startWidgetIndex) {

--- a/generated/ui_240x320/screens.h
+++ b/generated/ui_240x320/screens.h
@@ -199,6 +199,8 @@ typedef struct _objects_t {
     lv_obj_t *map_contrast_slider;
     lv_obj_t *map_style_dropdown;
     lv_obj_t *map_url_dropdown;
+    lv_obj_t *map_url_textarea;
+    lv_obj_t *keyboard_button_12;
     lv_obj_t *map_location_label;
     lv_obj_t *map_attribution_label;
     lv_obj_t *google_logo_image;

--- a/generated/ui_240x320/screens.h
+++ b/generated/ui_240x320/screens.h
@@ -199,6 +199,7 @@ typedef struct _objects_t {
     lv_obj_t *map_contrast_slider;
     lv_obj_t *map_style_dropdown;
     lv_obj_t *map_url_dropdown;
+    lv_obj_t *map_url_panel;
     lv_obj_t *map_url_textarea;
     lv_obj_t *keyboard_button_12;
     lv_obj_t *map_location_label;

--- a/generated/ui_320x240/screens.c
+++ b/generated/ui_320x240/screens.c
@@ -1565,8 +1565,8 @@ void create_screen_main_screen() {
                     // mapOSDPanel
                     lv_obj_t *obj = lv_obj_create(parent_obj);
                     objects.map_osd_panel = obj;
-                    lv_obj_set_pos(obj, 0, 5);
-                    lv_obj_set_size(obj, LV_PCT(80), 180);
+                    lv_obj_set_pos(obj, -15, 5);
+                    lv_obj_set_size(obj, LV_PCT(89), 180);
                     lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_set_style_bg_color(obj, lv_color_hex(0x101010), LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -1586,7 +1586,7 @@ void create_screen_main_screen() {
                             lv_obj_t *obj = lv_slider_create(parent_obj);
                             objects.map_brightness_slider = obj;
                             lv_obj_set_pos(obj, 0, 10);
-                            lv_obj_set_size(obj, LV_PCT(85), 8);
+                            lv_obj_set_size(obj, LV_PCT(78), 8);
                             lv_slider_set_range(obj, 0, 255);
                             lv_slider_set_value(obj, 200, LV_ANIM_OFF);
                             lv_obj_remove_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_ON_FOCUS|LV_OBJ_FLAG_SCROLL_WITH_ARROW);
@@ -1606,7 +1606,7 @@ void create_screen_main_screen() {
                             lv_obj_t *obj = lv_slider_create(parent_obj);
                             objects.map_contrast_slider = obj;
                             lv_obj_set_pos(obj, 0, 36);
-                            lv_obj_set_size(obj, LV_PCT(85), 8);
+                            lv_obj_set_size(obj, LV_PCT(78), 8);
                             lv_slider_set_range(obj, 30, 255);
                             lv_slider_set_value(obj, 200, LV_ANIM_OFF);
                             lv_obj_remove_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_ON_FOCUS|LV_OBJ_FLAG_SCROLL_WITH_ARROW);
@@ -1626,7 +1626,7 @@ void create_screen_main_screen() {
                             lv_obj_t *obj = lv_dropdown_create(parent_obj);
                             objects.map_style_dropdown = obj;
                             lv_obj_set_pos(obj, 0, 58);
-                            lv_obj_set_size(obj, LV_PCT(85), LV_SIZE_CONTENT);
+                            lv_obj_set_size(obj, LV_PCT(78), LV_SIZE_CONTENT);
                             lv_dropdown_set_options(obj, _("map tiles not found!"));
                             lv_dropdown_set_selected(obj, 0);
                             add_style_drop_down_style(obj);
@@ -1642,8 +1642,8 @@ void create_screen_main_screen() {
                             lv_obj_t *obj = lv_dropdown_create(parent_obj);
                             objects.map_url_dropdown = obj;
                             lv_obj_set_pos(obj, 0, 92);
-                            lv_obj_set_size(obj, LV_PCT(85), LV_SIZE_CONTENT);
-                            lv_dropdown_set_options(obj, _("Google Maps"));
+                            lv_obj_set_size(obj, LV_PCT(78), LV_SIZE_CONTENT);
+                            lv_dropdown_set_options(obj, _(""));
                             lv_dropdown_set_selected(obj, 0);
                             add_style_drop_down_style(obj);
                             lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -1652,6 +1652,37 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_left(obj, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_row(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_column(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+                        }
+                        {
+                            // mapUrlTextarea
+                            lv_obj_t *obj = lv_textarea_create(parent_obj);
+                            objects.map_url_textarea = obj;
+                            lv_obj_set_pos(obj, 0, 92);
+                            lv_obj_set_size(obj, LV_PCT(78), 27);
+                            lv_textarea_set_max_length(obj, 80);
+                            lv_textarea_set_placeholder_text(obj, "Enter URL template");
+                            lv_textarea_set_one_line(obj, true);
+                            lv_textarea_set_password_mode(obj, false);
+                            lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+                            lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
+                            lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_max_height(obj, 25, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_left(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+                        }
+                        {
+                            // KeyboardButton_12
+                            lv_obj_t *obj = lv_button_create(parent_obj);
+                            objects.keyboard_button_12 = obj;
+                            lv_obj_set_pos(obj, 224, 92);
+                            lv_obj_set_size(obj, 25, 25);
+                            lv_obj_set_style_align(obj, LV_ALIGN_DEFAULT, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_color(obj, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_image_src(obj, &img_keyboard_image, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_image_recolor(obj, lv_color_hex(0x373737), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_image_recolor_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
                 }
@@ -3303,7 +3334,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 245);
+                    create_user_widget_ok_cancel_widget(obj, 247);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3615,7 +3646,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 266);
+                    create_user_widget_ok_cancel_widget(obj, 268);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3661,7 +3692,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 272);
+                    create_user_widget_ok_cancel_widget(obj, 274);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3740,7 +3771,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 280);
+                    create_user_widget_ok_cancel_widget(obj, 282);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3787,7 +3818,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 286);
+                    create_user_widget_ok_cancel_widget(obj, 288);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3898,7 +3929,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 295);
+                    create_user_widget_ok_cancel_widget(obj, 297);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3962,7 +3993,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 302);
+                    create_user_widget_ok_cancel_widget(obj, 304);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4008,7 +4039,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 308);
+                    create_user_widget_ok_cancel_widget(obj, 310);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4073,7 +4104,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 315);
+                    create_user_widget_ok_cancel_widget(obj, 317);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4179,7 +4210,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 323);
+                    create_user_widget_ok_cancel_widget(obj, 325);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -4266,7 +4297,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 331);
+                    create_user_widget_ok_cancel_widget(obj, 333);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4342,7 +4373,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 338);
+                    create_user_widget_ok_cancel_widget(obj, 340);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4388,7 +4419,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 344);
+                    create_user_widget_ok_cancel_widget(obj, 346);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4465,7 +4496,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 351);
+                    create_user_widget_ok_cancel_widget(obj, 353);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4531,7 +4562,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 359);
+                    create_user_widget_ok_cancel_widget(obj, 361);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4576,7 +4607,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 365);
+                    create_user_widget_ok_cancel_widget(obj, 367);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4721,7 +4752,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 378);
+                    create_user_widget_ok_cancel_widget(obj, 380);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -6418,7 +6449,7 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            create_user_widget_ok_cancel_widget(obj, 485);
+                            create_user_widget_ok_cancel_widget(obj, 487);
                             lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
@@ -6480,24 +6511,24 @@ void create_screen_main_screen() {
 }
 
 void tick_screen_main_screen() {
-    tick_user_widget_ok_cancel_widget(245);
-    tick_user_widget_ok_cancel_widget(266);
-    tick_user_widget_ok_cancel_widget(272);
-    tick_user_widget_ok_cancel_widget(280);
-    tick_user_widget_ok_cancel_widget(286);
-    tick_user_widget_ok_cancel_widget(295);
-    tick_user_widget_ok_cancel_widget(302);
-    tick_user_widget_ok_cancel_widget(308);
-    tick_user_widget_ok_cancel_widget(315);
-    tick_user_widget_ok_cancel_widget(323);
-    tick_user_widget_ok_cancel_widget(331);
-    tick_user_widget_ok_cancel_widget(338);
-    tick_user_widget_ok_cancel_widget(344);
-    tick_user_widget_ok_cancel_widget(351);
-    tick_user_widget_ok_cancel_widget(359);
-    tick_user_widget_ok_cancel_widget(365);
-    tick_user_widget_ok_cancel_widget(378);
-    tick_user_widget_ok_cancel_widget(485);
+    tick_user_widget_ok_cancel_widget(247);
+    tick_user_widget_ok_cancel_widget(268);
+    tick_user_widget_ok_cancel_widget(274);
+    tick_user_widget_ok_cancel_widget(282);
+    tick_user_widget_ok_cancel_widget(288);
+    tick_user_widget_ok_cancel_widget(297);
+    tick_user_widget_ok_cancel_widget(304);
+    tick_user_widget_ok_cancel_widget(310);
+    tick_user_widget_ok_cancel_widget(317);
+    tick_user_widget_ok_cancel_widget(325);
+    tick_user_widget_ok_cancel_widget(333);
+    tick_user_widget_ok_cancel_widget(340);
+    tick_user_widget_ok_cancel_widget(346);
+    tick_user_widget_ok_cancel_widget(353);
+    tick_user_widget_ok_cancel_widget(361);
+    tick_user_widget_ok_cancel_widget(367);
+    tick_user_widget_ok_cancel_widget(380);
+    tick_user_widget_ok_cancel_widget(487);
 }
 
 void create_screen_blank_screen() {

--- a/generated/ui_320x240/screens.c
+++ b/generated/ui_320x240/screens.c
@@ -1578,7 +1578,15 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_left(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_pad_right(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_pad_row(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    lv_obj_set_style_pad_column(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_obj_set_style_pad_column(obj, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    {
+                        static lv_coord_t dsc[] = {0, LV_GRID_TEMPLATE_LAST};
+                        lv_obj_set_style_grid_row_dsc_array(obj, dsc, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    }
+                    {
+                        static lv_coord_t dsc[] = {0, LV_GRID_TEMPLATE_LAST};
+                        lv_obj_set_style_grid_column_dsc_array(obj, dsc, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    }
                     {
                         lv_obj_t *parent_obj = obj;
                         {
@@ -1654,35 +1662,53 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_column(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                         {
-                            // mapUrlTextarea
-                            lv_obj_t *obj = lv_textarea_create(parent_obj);
-                            objects.map_url_textarea = obj;
+                            // mapUrlPanel
+                            lv_obj_t *obj = lv_obj_create(parent_obj);
+                            objects.map_url_panel = obj;
                             lv_obj_set_pos(obj, 0, 92);
                             lv_obj_set_size(obj, LV_PCT(78), 27);
-                            lv_textarea_set_max_length(obj, 80);
-                            lv_textarea_set_placeholder_text(obj, "Enter URL template");
-                            lv_textarea_set_one_line(obj, true);
-                            lv_textarea_set_password_mode(obj, false);
-                            lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
-                            lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
+                            lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
+                            lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_align(obj, LV_ALIGN_TOP_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_max_height(obj, 25, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_pad_left(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
-                        }
-                        {
-                            // KeyboardButton_12
-                            lv_obj_t *obj = lv_button_create(parent_obj);
-                            objects.keyboard_button_12 = obj;
-                            lv_obj_set_pos(obj, 224, 92);
-                            lv_obj_set_size(obj, 25, 25);
-                            lv_obj_set_style_align(obj, LV_ALIGN_DEFAULT, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_color(obj, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_image_src(obj, &img_keyboard_image, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_image_recolor(obj, lv_color_hex(0x373737), LV_PART_MAIN | LV_STATE_DEFAULT);
-                            lv_obj_set_style_bg_image_recolor_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_left(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_pad_right(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                            {
+                                lv_obj_t *parent_obj = obj;
+                                {
+                                    // mapUrlTextarea
+                                    lv_obj_t *obj = lv_textarea_create(parent_obj);
+                                    objects.map_url_textarea = obj;
+                                    lv_obj_set_pos(obj, 0, 0);
+                                    lv_obj_set_size(obj, LV_PCT(87), 27);
+                                    lv_textarea_set_max_length(obj, 80);
+                                    lv_textarea_set_placeholder_text(obj, "Enter URL template");
+                                    lv_textarea_set_one_line(obj, true);
+                                    lv_textarea_set_password_mode(obj, false);
+                                    lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
+                                    lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_align(obj, LV_ALIGN_LEFT_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_max_height(obj, 25, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_pad_left(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_pad_right(obj, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                }
+                                {
+                                    // KeyboardButton_12
+                                    lv_obj_t *obj = lv_button_create(parent_obj);
+                                    objects.keyboard_button_12 = obj;
+                                    lv_obj_set_pos(obj, 0, 0);
+                                    lv_obj_set_size(obj, 25, 25);
+                                    lv_obj_set_style_bg_color(obj, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_bg_image_src(obj, &img_keyboard_image, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_bg_image_recolor(obj, lv_color_hex(0x373737), LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_bg_image_recolor_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                    lv_obj_set_style_align(obj, LV_ALIGN_RIGHT_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
+                                }
+                            }
                         }
                     }
                 }
@@ -3334,7 +3360,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 247);
+                    create_user_widget_ok_cancel_widget(obj, 248);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3646,7 +3672,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 268);
+                    create_user_widget_ok_cancel_widget(obj, 269);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3692,7 +3718,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 274);
+                    create_user_widget_ok_cancel_widget(obj, 275);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3771,7 +3797,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 282);
+                    create_user_widget_ok_cancel_widget(obj, 283);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3818,7 +3844,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 288);
+                    create_user_widget_ok_cancel_widget(obj, 289);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3929,7 +3955,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 297);
+                    create_user_widget_ok_cancel_widget(obj, 298);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -3993,7 +4019,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 304);
+                    create_user_widget_ok_cancel_widget(obj, 305);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4039,7 +4065,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 310);
+                    create_user_widget_ok_cancel_widget(obj, 311);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4104,7 +4130,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 317);
+                    create_user_widget_ok_cancel_widget(obj, 318);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4210,7 +4236,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 325);
+                    create_user_widget_ok_cancel_widget(obj, 326);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -4297,7 +4323,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 333);
+                    create_user_widget_ok_cancel_widget(obj, 334);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4373,7 +4399,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 340);
+                    create_user_widget_ok_cancel_widget(obj, 341);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4419,7 +4445,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 346);
+                    create_user_widget_ok_cancel_widget(obj, 347);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4496,7 +4522,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 353);
+                    create_user_widget_ok_cancel_widget(obj, 354);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4562,7 +4588,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 361);
+                    create_user_widget_ok_cancel_widget(obj, 362);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4607,7 +4633,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 367);
+                    create_user_widget_ok_cancel_widget(obj, 368);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
             }
@@ -4752,7 +4778,7 @@ void create_screen_main_screen() {
                     lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                    create_user_widget_ok_cancel_widget(obj, 380);
+                    create_user_widget_ok_cancel_widget(obj, 381);
                     lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                 }
                 {
@@ -6449,7 +6475,7 @@ void create_screen_main_screen() {
                             lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_bg_opa(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
                             lv_obj_set_style_border_width(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-                            create_user_widget_ok_cancel_widget(obj, 487);
+                            create_user_widget_ok_cancel_widget(obj, 488);
                             lv_obj_set_style_align(obj, LV_ALIGN_BOTTOM_MID, LV_PART_MAIN | LV_STATE_DEFAULT);
                         }
                     }
@@ -6511,24 +6537,24 @@ void create_screen_main_screen() {
 }
 
 void tick_screen_main_screen() {
-    tick_user_widget_ok_cancel_widget(247);
-    tick_user_widget_ok_cancel_widget(268);
-    tick_user_widget_ok_cancel_widget(274);
-    tick_user_widget_ok_cancel_widget(282);
-    tick_user_widget_ok_cancel_widget(288);
-    tick_user_widget_ok_cancel_widget(297);
-    tick_user_widget_ok_cancel_widget(304);
-    tick_user_widget_ok_cancel_widget(310);
-    tick_user_widget_ok_cancel_widget(317);
-    tick_user_widget_ok_cancel_widget(325);
-    tick_user_widget_ok_cancel_widget(333);
-    tick_user_widget_ok_cancel_widget(340);
-    tick_user_widget_ok_cancel_widget(346);
-    tick_user_widget_ok_cancel_widget(353);
-    tick_user_widget_ok_cancel_widget(361);
-    tick_user_widget_ok_cancel_widget(367);
-    tick_user_widget_ok_cancel_widget(380);
-    tick_user_widget_ok_cancel_widget(487);
+    tick_user_widget_ok_cancel_widget(248);
+    tick_user_widget_ok_cancel_widget(269);
+    tick_user_widget_ok_cancel_widget(275);
+    tick_user_widget_ok_cancel_widget(283);
+    tick_user_widget_ok_cancel_widget(289);
+    tick_user_widget_ok_cancel_widget(298);
+    tick_user_widget_ok_cancel_widget(305);
+    tick_user_widget_ok_cancel_widget(311);
+    tick_user_widget_ok_cancel_widget(318);
+    tick_user_widget_ok_cancel_widget(326);
+    tick_user_widget_ok_cancel_widget(334);
+    tick_user_widget_ok_cancel_widget(341);
+    tick_user_widget_ok_cancel_widget(347);
+    tick_user_widget_ok_cancel_widget(354);
+    tick_user_widget_ok_cancel_widget(362);
+    tick_user_widget_ok_cancel_widget(368);
+    tick_user_widget_ok_cancel_widget(381);
+    tick_user_widget_ok_cancel_widget(488);
 }
 
 void create_screen_blank_screen() {

--- a/generated/ui_320x240/screens.h
+++ b/generated/ui_320x240/screens.h
@@ -196,6 +196,8 @@ typedef struct _objects_t {
     lv_obj_t *map_contrast_slider;
     lv_obj_t *map_style_dropdown;
     lv_obj_t *map_url_dropdown;
+    lv_obj_t *map_url_textarea;
+    lv_obj_t *keyboard_button_12;
     lv_obj_t *map_location_label;
     lv_obj_t *map_attribution_label;
     lv_obj_t *google_logo_image;

--- a/generated/ui_320x240/screens.h
+++ b/generated/ui_320x240/screens.h
@@ -196,6 +196,7 @@ typedef struct _objects_t {
     lv_obj_t *map_contrast_slider;
     lv_obj_t *map_style_dropdown;
     lv_obj_t *map_url_dropdown;
+    lv_obj_t *map_url_panel;
     lv_obj_t *map_url_textarea;
     lv_obj_t *keyboard_button_12;
     lv_obj_t *map_location_label;

--- a/include/graphics/common/SdCard.h
+++ b/include/graphics/common/SdCard.h
@@ -13,6 +13,7 @@ extern fs::SDMMCFS &SDFs;
 extern SdFs SDFs;
 #endif
 
+#include <cstdint>
 #include <set>
 #include <string>
 
@@ -69,6 +70,7 @@ class ISdCard
     virtual std::set<std::string> loadMapStyles(const char *folder) = 0;
     virtual bool hasMapArchive(const char *folder, const char *style) = 0;
     virtual std::string getUrlProvider(const char *folder, const char *style) = 0;
+    virtual bool setUrlProvider(const char *folder, const char *style, const char *urlTemplate) = 0;
     virtual ~ISdCard(void) {}
 
   protected:
@@ -93,6 +95,7 @@ class SDCard : public ISdCard
     std::set<std::string> loadMapStyles(const char *folder) override;
     bool hasMapArchive(const char *folder, const char *style) override;
     std::string getUrlProvider(const char *folder, const char *style) override;
+    bool setUrlProvider(const char *folder, const char *style, const char *urlTemplate) override;
     virtual ~SDCard(void);
 };
 
@@ -112,6 +115,7 @@ class SdFsCard : public ISdCard
     std::set<std::string> loadMapStyles(const char *folder) override;
     bool hasMapArchive(const char *folder, const char *style) override;
     std::string getUrlProvider(const char *folder, const char *style) override;
+    bool setUrlProvider(const char *folder, const char *style, const char *urlTemplate) override;
     virtual ~SdFsCard(void) {}
 };
 
@@ -147,6 +151,7 @@ class RemoteSdCard : public ISdCard
     std::set<std::string> loadMapStyles(const char *folder) override;
     bool hasMapArchive(const char *folder, const char *style) override;
     std::string getUrlProvider(const char *folder, const char *style) override;
+    bool setUrlProvider(const char *folder, const char *style, const char *urlTemplate) override;
     virtual ~RemoteSdCard(void) {}
 
   private:
@@ -177,6 +182,7 @@ class NoSdCard : public ISdCard
     }
     bool hasMapArchive(const char *folder, const char *style) override { return false; }
     std::string getUrlProvider(const char *folder, const char *style) override { return {}; }
+    bool setUrlProvider(const char *folder, const char *style, const char *urlTemplate) override { return false; }
     virtual ~NoSdCard(void) {}
 };
 

--- a/include/graphics/map/TileProvider.h
+++ b/include/graphics/map/TileProvider.h
@@ -4,6 +4,8 @@
 #include <tuple>
 #include <vector>
 
+#define URL_UNSET "URL: <unset>"
+
 class TileProvider
 {
   public:

--- a/include/graphics/view/TFT/TFTView_320x240.h
+++ b/include/graphics/view/TFT/TFTView_320x240.h
@@ -206,6 +206,8 @@ class TFTView_320x240 : public MeshtasticView
     virtual void addOrUpdateMap(uint32_t nodeNum, int32_t lat, int32_t lon);
     // remove objects from map
     virtual void removeFromMap(uint32_t nodeNum);
+    // show or hide URL template input
+    virtual void showUrlInputArea(bool show);
 
     std::function<void(uint32_t id, uint16_t x, uint16_t y, uint8_t)> drawObjectCB;
 
@@ -360,6 +362,7 @@ class TFTView_320x240 : public MeshtasticView
     static void ui_event_setup_region_dropdown(lv_event_t *e);
     static void ui_event_map_style_dropdown(lv_event_t *e);
     static void ui_event_map_url_dropdown(lv_event_t *e);
+    static void ui_event_map_url_textarea(lv_event_t *e);
 
     static void ui_event_calibration_screen_loaded(lv_event_t *e);
 

--- a/include/graphics/view/TFT/TFTView_320x240.h
+++ b/include/graphics/view/TFT/TFTView_320x240.h
@@ -206,6 +206,8 @@ class TFTView_320x240 : public MeshtasticView
     virtual void addOrUpdateMap(uint32_t nodeNum, int32_t lat, int32_t lon);
     // remove objects from map
     virtual void removeFromMap(uint32_t nodeNum);
+    // set url provider and dropdown and return url if present
+    virtual std::string setUrlProvider(const char *style);
     // show or hide URL template input
     virtual void showUrlInputArea(bool show);
 

--- a/include/util/About.h
+++ b/include/util/About.h
@@ -31,7 +31,7 @@
     "Open Database License\n"                                                                                                    \
     "openstreetmap.org/copyright"
 
-// PMTiles attribution
+// PNGDec attribution
 #define ABOUT_PNGDEC_TEXT                                                                                                        \
     "[PNG Decoder Engine]\n"                                                                                                     \
     "PNGdec Library by Larry Bank\n"                                                                                             \
@@ -47,7 +47,7 @@
     "Licensed under BSD 3-Clause\n"                                                                                              \
     "github.com/pmtiles/LICENSE"
 
-// PMTiles attribution
+// libdeflate attribution
 #define ABOUT_LIBDEFLATE_TEXT                                                                                                    \
     "[Decompression Engine]\n"                                                                                                   \
     "libdeflate Library by E. Biggers\n"                                                                                         \

--- a/maps/README.md
+++ b/maps/README.md
@@ -69,12 +69,20 @@ There are several ways to generate the protomaps .pmtiles format:
 
 Finally put the style.pmtiles archive into the maps/style folder on SD card. Don't forget to also drop a matching .url file into the same style folder if you want automatic WiFi map tile downloads of missing tiles.
 
-> **NOTE:**
-> protomaps cloud services are coming soon™.
+### Self-hosting Protomaps
+
+With the following command you can serve pmtiles in your network:
+   ```bash
+   go run main.go serve .
+   ```
+
+This will provide access to all pmtiles in the current directory. The URL template to access e.g. *style.pmtiles* is
+`http://host-ip:8080/style/{z}/{x}/{y}.png`.
+
 
 ## WiFi Download
 
-If WiFi is enabled and an internet connection is present then map tiles that are not found on SD card are downloaded via the internet. To achieve this you have to provide your own [raster map style URL template](https://wiki.openstreetmap.org/wiki/Raster_tile_providers) by putting a tiles .url file into the style folder. This file must contain a single line with the url template to download from. The link above gives you a choice of ~50 download URLs. Once an .url file is found in the style folder all successfully downloaded map tiles are also stored in the same style folder of the SD card. This also works in parallel with pmtiles, i.e. tiles not found in the pmtiles archive nor in the xyz folder structure are downloaded via the provided URL and stored back on SD card (note: the pmtiles archive is read-only and will not be touched).
+If WiFi is enabled and an internet connection is present then map tiles that are not found on SD card are downloaded via the internet. To achieve this you have to provide your own [raster map style URL template](https://wiki.openstreetmap.org/wiki/Raster_tile_providers) either by entering it into the URL text field of the map options panel or by putting a tiles .url file into the style folder of the SD card. This file must contain a single line with the url template to download from. The link above gives you a choice of ~50 download URLs. Once an .url file is found in the style folder all successfully downloaded map tiles are also stored in the same style folder of the SD card. This also works in parallel with pmtiles, i.e. tiles not found in the pmtiles archive nor in the xyz folder structure are downloaded via the provided URL and stored back on SD card (note: the pmtiles archive is read-only and will not be touched).
 
 # Extra maps
 
@@ -109,10 +117,12 @@ Bundles can be found [here](https://download.tiles.coalition.space/bundles) and 
 
 # Compatibility
 
+- 🟢 **Seeed Wio Tracker L2**: Confirmed to work with Fat32 formatted SD. Due to SDIO bus exFat is not yet supported.
+- 🟢 **Elecrow ThinkNode M9**: Confirmed to work, except some functionality is not yet available via keypad.
 - 🟢 **LILYGO T-Deck**: Confirmed to work
 - 🟢 **CrowPanel Advance HMI**: Confirmed to work on 2.4", 2.8", and 3.5" models
 - 🟢 **Seeed SenseCAP Indicator**: The MicroSD card slot is physically not connected with the ESP32-S3 where the MUI is running. To access it it requires a [firmware download](https://github.com/meshtastic/indicator_rp2040/releases) and flashing to the RP2040 coprocessor.
-- 🟡/🟢 **Heltec V4 Kit**: The older version does not have a MicroSD card slot and the available PSRAM is only 2 MB. When WiFi is enabled then map tiles are downloaded via the internet and converted into grayscale tiles to lower the memory consumption. The 8MB PSRAM version has full map support.
+- 🟡/🟢 **Heltec V4 Kit**: The older version does not have a MicroSD card slot and the available PSRAM is just 2 MB. When WiFi is enabled then map tiles are downloaded via the internet and converted into grayscale tiles to lower the memory consumption. The 8MB PSRAM version has full colored map support.
 
 # Credits and Attribution
 

--- a/maps/README.md
+++ b/maps/README.md
@@ -119,7 +119,7 @@ Bundles can be found [here](https://download.tiles.coalition.space/bundles) and 
 
 # Compatibility
 
-- 🟢 **Seeed Wio Tracker L2**: Confirmed to work with Fat32 formatted SD. Due to SDIO bus exFat is not yet supported.
+- 🟢 **Seeed Wio Tracker L2**: Confirmed to work with Fat32 formatted SD. Due to the SDIO bus driver exFat is not yet supported.
 - 🟢 **Elecrow ThinkNode M9**: Confirmed to work, except some functionality is not yet available via keypad.
 - 🟢 **LILYGO T-Deck**: Confirmed to work
 - 🟢 **CrowPanel Advance HMI**: Confirmed to work on 2.4", 2.8", and 3.5" models

--- a/maps/README.md
+++ b/maps/README.md
@@ -43,15 +43,17 @@ If you like to check of how many tiles an area is composed of you can make use o
 
 ## Protomaps (.pmtiles)
 
-MUI >= 2.8.1 supports [protomaps](https://protomaps.com) [pmtiles](https://github.com/protomaps/PMTiles) format, i.e. all downloaded .png raster tiles can be packed into a single compressed file which is then put into the SD cards' styles folder with the same name as the style directory itself, e.g. maps/OSM/OSM.pmtiles. Upon map style selection MUI will check for existence of such .pmtiles file and automatically load the required tiles from the archive.
+MUI >= 2.8.1 supports [protomaps](https://protomaps.com) [PMTiles](https://github.com/protomaps/PMTiles) png raster format, i.e. all downloaded .png raster tiles can be packed into a single PMTiles archive which is then put into the SD cards' styles folder with the exact same basename as the style directory itself, e.g. `maps/OSM/OSM.pmtiles`. Upon map style selection MUI will check for existence of such .pmtiles file and automatically load the required tiles from the archive. Tiles not found in the archive will be searched in the z/x/y directory and if that fails downloaded via [WiFi](#wifi-download) if connected. The PMTiles archive on SD card is read-only and downloaded fallback tiles are stored beside it in the tile directories 0-19.
+
+Note, that not all .pmtiles are automatically supported, e.g. those that contain .jpg or vector tiles format won't work with MUI.
 
 There are several ways to generate the protomaps .pmtiles format:
 
 1. Download xyz raster tiles in mbtiles format (e.g. using [QGIS](https://qgis.org) or [maptiler engine](https://www.maptiler.com/engine))
-   and convert the mbtiles archive to pmtiles using https://github.com/protomaps/go-pmtiles :
+   and convert the mbtiles archive to pmtiles using https://github.com/protomaps/go-pmtiles/releases :
 
    ```bash
-   go run main.go convert style.mbtiles style.pmtiles
+   pmtiles convert style.mbtiles style.pmtiles
    ```
 
 2. Convert your existing xyz tiles folder directly into pmtiles using [versaTiles](https://docs.versatiles.org/) .

--- a/maps/README.md
+++ b/maps/README.md
@@ -72,13 +72,13 @@ Finally put the style.pmtiles archive into the maps/style folder on SD card. Don
 ### Self-hosting Protomaps
 
 With the following command you can serve pmtiles in your network:
-   ```bash
-   go run main.go serve .
-   ```
 
-This will provide access to all pmtiles in the current directory. The URL template to access e.g. *style.pmtiles* is
+```bash
+go run main.go serve .
+```
+
+This will provide access to all pmtiles in the current directory. The URL template to access e.g. _style.pmtiles_ is
 `http://host-ip:8080/style/{z}/{x}/{y}.png`.
-
 
 ## WiFi Download
 

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -797,6 +797,7 @@ void TFTView_320x240::ui_events_init(void)
     lv_obj_add_event_cb(objects.keyboard_button_9, ui_event_KeyboardButton, LV_EVENT_CLICKED, (void *)9);
     lv_obj_add_event_cb(objects.keyboard_button_10, ui_event_KeyboardButton, LV_EVENT_CLICKED, (void *)10);
     lv_obj_add_event_cb(objects.keyboard_button_11, ui_event_KeyboardButton, LV_EVENT_CLICKED, (void *)11);
+    lv_obj_add_event_cb(objects.keyboard_button_12, ui_event_KeyboardButton, LV_EVENT_CLICKED, (void *)12);
 
     // message text area
     lv_obj_add_event_cb(objects.message_input_area, ui_event_message_ready, LV_EVENT_ALL, NULL);
@@ -912,6 +913,8 @@ void TFTView_320x240::ui_events_init(void)
     lv_obj_add_event_cb(objects.map_contrast_slider, ui_event_mapContrastSlider, LV_EVENT_VALUE_CHANGED, NULL);
     lv_obj_add_event_cb(objects.map_style_dropdown, ui_event_map_style_dropdown, LV_EVENT_VALUE_CHANGED, NULL);
     lv_obj_add_event_cb(objects.map_url_dropdown, ui_event_map_url_dropdown, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_obj_add_event_cb(objects.map_url_textarea, ui_event_map_url_textarea, LV_EVENT_KEY, NULL);
+    lv_obj_add_event_cb(objects.map_url_textarea, ui_event_map_url_textarea, LV_EVENT_READY, NULL);
 
     // tools buttons
     lv_obj_add_event_cb(objects.tools_mesh_detector_button, ui_event_mesh_detector, LV_EVENT_CLICKED, 0);
@@ -1664,6 +1667,10 @@ void TFTView_320x240::ui_event_KeyboardButton(lv_event_t *e)
         case 11:
             THIS->showKeyboard(objects.setup_user_long_textarea);
             lv_group_focus_obj(objects.setup_user_long_textarea);
+            break;
+        case 12:
+            THIS->showKeyboard(objects.map_url_textarea);
+            lv_group_focus_obj(objects.map_url_textarea);
             break;
         default:
             ILOG_ERROR("missing keyboard <-> textarea assignment");
@@ -2422,6 +2429,57 @@ void TFTView_320x240::ui_event_map_url_dropdown(lv_event_t *e)
     THIS->map->forceRedraw();
 }
 
+/**
+ * Check if url template is valid
+ */
+void TFTView_320x240::ui_event_map_url_textarea(lv_event_t *e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+    if (event_code == LV_EVENT_KEY) {
+        uint32_t *key = (uint32_t *)lv_event_get_param(e);
+        if (!key || *key != '\r')
+            return;
+        event_code = LV_EVENT_READY;
+    }
+    if (event_code == LV_EVENT_READY) {
+        std::string url = lv_textarea_get_text(objects.map_url_textarea);
+        if (!url.empty()) {
+            bool urlOk = (url.find("https://") == 0 || url.find("http://") == 0) &&
+                         url.find("{x}") != std::string::npos &&
+                         url.find("{y}") != std::string::npos &&
+                         url.find("{z}") != std::string::npos;
+
+            if (urlOk) {
+                ILOG_DEBUG("using user url template: %s", url.c_str());
+                std::string defaultStyle = "default";
+                char style[40];
+                lv_dropdown_get_selected_str(objects.map_style_dropdown, style, sizeof(style));
+                if (strlen(style) > 0) {
+                    defaultStyle = style;
+                }
+                lv_obj_set_style_border_color(objects.map_url_textarea, colorBlueGreen, LV_PART_MAIN | LV_STATE_DEFAULT);
+                int entry = TileProvider::addTemplate("URL: " + defaultStyle, url);
+                TileProvider::selectTemplate(entry);
+                if (sdCard && sdCard->isUpdated() && sdCard->cardType() != ISdCard::eNone) {
+                    if (sdCard->setUrlProvider(MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str()))
+                        MapTileSettings::setSaveOK(true);
+                    else 
+                        ILOG_ERROR("failed to write %s/%s/.url: %s", MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str());
+                }
+                lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
+                THIS->map->forceRedraw();
+                THIS->attribution(url);
+            }
+            else {
+                ILOG_WARN("wrong user url: %s", url.c_str());
+                lv_obj_set_style_border_color(objects.map_url_textarea, colorRed, LV_PART_MAIN | LV_STATE_DEFAULT);
+                MapTileSettings::setSaveOK(false);
+            }
+        }
+    }
+}
+
 void TFTView_320x240::ui_event_mapNodeButton(lv_event_t *e)
 {
     // navigate to node in node list
@@ -2432,6 +2490,20 @@ void TFTView_320x240::ui_event_mapNodeButton(lv_event_t *e)
     lv_obj_scroll_to_view(panel, LV_ANIM_ON);
     if (panel != currentPanel)
         ui_event_NodeButton(e);
+}
+
+void TFTView_320x240::showUrlInputArea(bool show)
+{
+    if (show) {
+        lv_obj_remove_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_remove_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
+    }
+    else {
+        lv_obj_add_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_remove_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
 void TFTView_320x240::ui_event_chatNodeButton(lv_event_t *e)
@@ -2710,6 +2782,7 @@ void TFTView_320x240::loadMap(void)
                 char savedTileDir[MapTileSettings::TILE_STYLE_SIZE];
                 MapTileSettings::styleToDir(db.uiConfig.map_data.style, savedTileDir, sizeof(savedTileDir));
                 lv_dropdown_clear_options(objects.map_style_dropdown);
+                lv_dropdown_clear_options(objects.map_url_dropdown);
                 for (auto it : mapStyles) {
                     // add url provider if exist
                     int urlEntry = -1;
@@ -2747,6 +2820,8 @@ void TFTView_320x240::loadMap(void)
                 } else {
                     lv_dropdown_clear_options(objects.map_url_dropdown);
                 }
+                showUrlInputArea(providers.empty());
+
                 if (!savedStyleOK) {
                     // no such style on SD, pick first one we found
                     char style[30];
@@ -2767,13 +2842,16 @@ void TFTView_320x240::loadMap(void)
                 MapTileSettings::setPrefix("/maps");
             } else {
                 MapTileSettings::setPMTiles(false);
+                showUrlInputArea(true);
                 // messageAlert(_("No map tiles found on SDCard!"), true);
             }
             map->forceRedraw();
         }
     } else {
         MapTileSettings::setPMTiles(false);
+        showUrlInputArea(true);
         lv_dropdown_clear_options(objects.map_style_dropdown);
+        lv_dropdown_clear_options(objects.map_url_dropdown);
     }
 
     MapTileSettings::setUniqueId(ownNode);

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2509,12 +2509,14 @@ void TFTView_320x240::ui_event_mapNodeButton(lv_event_t *e)
 void TFTView_320x240::showUrlInputArea(bool show)
 {
     if (show) {
-        lv_obj_remove_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_remove_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_remove_flag(objects.map_url_panel, LV_OBJ_FLAG_HIDDEN);
+//        lv_obj_remove_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
+//        lv_obj_remove_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
     } else {
-        lv_obj_add_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(objects.map_url_panel, LV_OBJ_FLAG_HIDDEN);
+//        lv_obj_add_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
+//        lv_obj_add_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
         lv_obj_remove_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
     }
 }

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2400,7 +2400,7 @@ void TFTView_320x240::ui_event_map_style_dropdown(lv_event_t *e)
     char style[MapTileSettings::TILE_STYLE_SIZE];
     lv_dropdown_get_selected_str(objects.map_style_dropdown, style, sizeof(style));
     if (strcmp(style, THIS->db.uiConfig.map_data.style) != 0) {
-        strcpy (THIS->db.uiConfig.map_data.style, style);
+        strcpy(THIS->db.uiConfig.map_data.style, style);
         MapTileSettings::setTileStyle(THIS->db.uiConfig.map_data.style);
         std::string url = THIS->setUrlProvider(THIS->db.uiConfig.map_data.style);
         MapTileSettings::setSaveOK(!url.empty()); // enable SD save if .url exists
@@ -2408,8 +2408,7 @@ void TFTView_320x240::ui_event_map_style_dropdown(lv_event_t *e)
         THIS->controller->storeUIConfig(THIS->db.uiConfig);
         lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
         THIS->map->forceRedraw();
-    }
-    else {
+    } else {
         // copy current url template into textarea for editing
         THIS->showUrlInputArea(true);
         std::string url = sdCard->getUrlProvider(MapTileSettings::getPrefix(), style);
@@ -2424,8 +2423,7 @@ void TFTView_320x240::ui_event_map_url_dropdown(lv_event_t *e)
     lv_dropdown_get_selected_str(objects.map_url_dropdown, url, sizeof(url));
     if (strcmp(url, _(URL_UNSET)) == 0) {
         THIS->showUrlInputArea(true);
-    }
-    else {
+    } else {
         uint32_t urlId = lv_dropdown_get_selected(objects.map_url_dropdown);
         TileProvider::selectTemplate(urlId);
         MapTileSettings::setSaveOK(false);
@@ -2450,10 +2448,8 @@ void TFTView_320x240::ui_event_map_url_textarea(lv_event_t *e)
     if (event_code == LV_EVENT_READY) {
         std::string url = lv_textarea_get_text(objects.map_url_textarea);
         if (!url.empty()) {
-            bool urlOk = (url.find("https://") == 0 || url.find("http://") == 0) &&
-                         url.find("{x}") != std::string::npos &&
-                         url.find("{y}") != std::string::npos &&
-                         url.find("{z}") != std::string::npos;
+            bool urlOk = (url.find("https://") == 0 || url.find("http://") == 0) && url.find("{x}") != std::string::npos &&
+                         url.find("{y}") != std::string::npos && url.find("{z}") != std::string::npos;
 
             if (urlOk) {
                 ILOG_DEBUG("using user url template: %s", url.c_str());
@@ -2473,27 +2469,24 @@ void TFTView_320x240::ui_event_map_url_textarea(lv_event_t *e)
                     if (sdCard->setUrlProvider(MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str())) {
                         THIS->showUrlInputArea(false);
                         MapTileSettings::setSaveOK(true);
-                    }
-                    else 
-                        ILOG_ERROR("failed to write %s/%s/.url: %s", MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str());
+                    } else
+                        ILOG_ERROR("failed to write %s/%s/.url: %s", MapTileSettings::getPrefix(), defaultStyle.c_str(),
+                                   url.c_str());
                 }
                 lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
                 lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
                 THIS->map->forceRedraw();
                 THIS->attribution(url);
-            }
-            else {
+            } else {
                 ILOG_WARN("wrong user url: %s", url.c_str());
                 lv_obj_set_style_border_color(objects.map_url_textarea, colorRed, LV_PART_MAIN | LV_STATE_DEFAULT);
                 MapTileSettings::setSaveOK(false);
             }
-        }
-        else {
+        } else {
             if (lv_dropdown_get_option_count(objects.map_url_dropdown) > 0) {
                 lv_obj_set_style_border_color(objects.map_url_textarea, lv_color_hex(0xe0e0e0), LV_PART_MAIN | LV_STATE_DEFAULT);
                 lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
                 THIS->showUrlInputArea(false);
-
             }
         }
     }
@@ -2517,8 +2510,7 @@ void TFTView_320x240::showUrlInputArea(bool show)
         lv_obj_remove_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
         lv_obj_remove_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
-    }
-    else {
+    } else {
         lv_obj_add_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
         lv_obj_remove_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
@@ -2838,9 +2830,8 @@ void TFTView_320x240::loadMap(void)
                     lv_dropdown_set_selected(objects.map_style_dropdown, 0);
                     lv_dropdown_get_selected_str(objects.map_style_dropdown, style, sizeof(style));
                     MapTileSettings::setTileStyle(style);
-                }
-                else {
-                    strcpy (style, savedTileDir);
+                } else {
+                    strcpy(style, savedTileDir);
                 }
                 std::string url = setUrlProvider(style);
                 if (!url.empty())
@@ -2971,8 +2962,7 @@ std::string TFTView_320x240::setUrlProvider(const char *style)
         lv_dropdown_set_selected(objects.map_url_dropdown, entry);
         TileProvider::selectTemplate(entry);
         THIS->attribution(url);
-    }
-    else {
+    } else {
         // no .url found for current style; add a <unset>> field if not exist
         ILOG_DEBUG("set provider url to %s", _(URL_UNSET));
         int32_t option = lv_dropdown_get_option_index(objects.map_url_dropdown, _(URL_UNSET));
@@ -2980,14 +2970,12 @@ std::string TFTView_320x240::setUrlProvider(const char *style)
         if (option < 0) {
             lv_dropdown_add_option(objects.map_url_dropdown, _(URL_UNSET), LV_DROPDOWN_POS_LAST);
             lv_dropdown_set_selected(objects.map_url_dropdown, entries);
-        }
-        else {
+        } else {
             lv_dropdown_set_selected(objects.map_url_dropdown, option);
         }
     }
     return url;
 }
-
 
 void TFTView_320x240::ui_event_mesh_detector(lv_event_t *e)
 {

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2510,13 +2510,13 @@ void TFTView_320x240::showUrlInputArea(bool show)
 {
     if (show) {
         lv_obj_remove_flag(objects.map_url_panel, LV_OBJ_FLAG_HIDDEN);
-//        lv_obj_remove_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
-//        lv_obj_remove_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
+        //        lv_obj_remove_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
+        //        lv_obj_remove_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
     } else {
         lv_obj_add_flag(objects.map_url_panel, LV_OBJ_FLAG_HIDDEN);
-//        lv_obj_add_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
-//        lv_obj_add_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
+        //        lv_obj_add_flag(objects.map_url_textarea, LV_OBJ_FLAG_HIDDEN);
+        //        lv_obj_add_flag(objects.keyboard_button_12, LV_OBJ_FLAG_HIDDEN);
         lv_obj_remove_flag(objects.map_url_dropdown, LV_OBJ_FLAG_HIDDEN);
     }
 }

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2422,6 +2422,8 @@ void TFTView_320x240::ui_event_map_url_dropdown(lv_event_t *e)
     char url[128];
     lv_dropdown_get_selected_str(objects.map_url_dropdown, url, sizeof(url));
     if (strcmp(url, _(URL_UNSET)) == 0) {
+        lv_textarea_set_text(objects.map_url_textarea, "");
+        lv_obj_set_style_border_color(objects.map_url_textarea, lv_color_hex(0xe0e0e0), LV_PART_MAIN | LV_STATE_DEFAULT);
         THIS->showUrlInputArea(true);
     } else {
         uint32_t urlId = lv_dropdown_get_selected(objects.map_url_dropdown);

--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -2397,36 +2397,42 @@ void TFTView_320x240::ui_event_mapContrastSlider(lv_event_t *e)
 
 void TFTView_320x240::ui_event_map_style_dropdown(lv_event_t *e)
 {
-    lv_dropdown_get_selected_str(objects.map_style_dropdown, THIS->db.uiConfig.map_data.style,
-                                 sizeof(THIS->db.uiConfig.map_data.style));
-    MapTileSettings::setTileStyle(THIS->db.uiConfig.map_data.style);
-    // set url provider if exist
-    char tileDir[MapTileSettings::TILE_STYLE_SIZE];
-    MapTileSettings::styleToDir(THIS->db.uiConfig.map_data.style, tileDir, sizeof(tileDir));
-    MapTileSettings::setPMTiles(sdCard && sdCard->hasMapArchive(MapTileSettings::getPrefix(), tileDir));
-    std::string url = sdCard->getUrlProvider(MapTileSettings::getPrefix(), tileDir);
-    if (!url.empty()) {
-        std::string provider = std::string("URL: ") + THIS->db.uiConfig.map_data.style;
-        int entry = TileProvider::addTemplate(provider, url);
-        lv_dropdown_set_selected(objects.map_url_dropdown, entry);
-        TileProvider::selectTemplate(entry);
-        THIS->attribution(url);
+    char style[MapTileSettings::TILE_STYLE_SIZE];
+    lv_dropdown_get_selected_str(objects.map_style_dropdown, style, sizeof(style));
+    if (strcmp(style, THIS->db.uiConfig.map_data.style) != 0) {
+        strcpy (THIS->db.uiConfig.map_data.style, style);
+        MapTileSettings::setTileStyle(THIS->db.uiConfig.map_data.style);
+        std::string url = THIS->setUrlProvider(THIS->db.uiConfig.map_data.style);
+        MapTileSettings::setSaveOK(!url.empty()); // enable SD save if .url exists
+        THIS->showUrlInputArea(false);
+        THIS->controller->storeUIConfig(THIS->db.uiConfig);
+        lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
+        THIS->map->forceRedraw();
     }
-    MapTileSettings::setSaveOK(!url.empty()); // enable SD save if .url exists
-
-    THIS->controller->storeUIConfig(THIS->db.uiConfig);
-    lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
-    THIS->map->forceRedraw();
+    else {
+        // copy current url template into textarea for editing
+        THIS->showUrlInputArea(true);
+        std::string url = sdCard->getUrlProvider(MapTileSettings::getPrefix(), style);
+        lv_textarea_set_text(objects.map_url_textarea, url.c_str());
+        lv_group_focus_obj(objects.map_url_textarea);
+    }
 }
 
 void TFTView_320x240::ui_event_map_url_dropdown(lv_event_t *e)
 {
-    uint32_t urlId = lv_dropdown_get_selected(objects.map_url_dropdown);
-    TileProvider::selectTemplate(urlId);
-    MapTileSettings::setSaveOK(false);
-    lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
-    THIS->attribution(TileProvider::url());
-    THIS->map->forceRedraw();
+    char url[128];
+    lv_dropdown_get_selected_str(objects.map_url_dropdown, url, sizeof(url));
+    if (strcmp(url, _(URL_UNSET)) == 0) {
+        THIS->showUrlInputArea(true);
+    }
+    else {
+        uint32_t urlId = lv_dropdown_get_selected(objects.map_url_dropdown);
+        TileProvider::selectTemplate(urlId);
+        MapTileSettings::setSaveOK(false);
+        lv_obj_add_flag(objects.map_osd_panel, LV_OBJ_FLAG_HIDDEN);
+        THIS->attribution(TileProvider::url());
+        THIS->map->forceRedraw();
+    }
 }
 
 /**
@@ -2460,9 +2466,14 @@ void TFTView_320x240::ui_event_map_url_textarea(lv_event_t *e)
                 lv_obj_set_style_border_color(objects.map_url_textarea, colorBlueGreen, LV_PART_MAIN | LV_STATE_DEFAULT);
                 int entry = TileProvider::addTemplate("URL: " + defaultStyle, url);
                 TileProvider::selectTemplate(entry);
-                if (sdCard && sdCard->isUpdated() && sdCard->cardType() != ISdCard::eNone) {
-                    if (sdCard->setUrlProvider(MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str()))
+                auto providers = TileProvider::providers();
+                lv_dropdown_set_options(objects.map_url_dropdown, providers.c_str());
+                lv_dropdown_set_selected(objects.map_url_dropdown, entry);
+                if (sdCard) {
+                    if (sdCard->setUrlProvider(MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str())) {
+                        THIS->showUrlInputArea(false);
                         MapTileSettings::setSaveOK(true);
+                    }
                     else 
                         ILOG_ERROR("failed to write %s/%s/.url: %s", MapTileSettings::getPrefix(), defaultStyle.c_str(), url.c_str());
                 }
@@ -2475,6 +2486,14 @@ void TFTView_320x240::ui_event_map_url_textarea(lv_event_t *e)
                 ILOG_WARN("wrong user url: %s", url.c_str());
                 lv_obj_set_style_border_color(objects.map_url_textarea, colorRed, LV_PART_MAIN | LV_STATE_DEFAULT);
                 MapTileSettings::setSaveOK(false);
+            }
+        }
+        else {
+            if (lv_dropdown_get_option_count(objects.map_url_dropdown) > 0) {
+                lv_obj_set_style_border_color(objects.map_url_textarea, lv_color_hex(0xe0e0e0), LV_PART_MAIN | LV_STATE_DEFAULT);
+                lv_obj_add_flag(objects.keyboard, LV_OBJ_FLAG_HIDDEN);
+                THIS->showUrlInputArea(false);
+
             }
         }
     }
@@ -2776,9 +2795,6 @@ void TFTView_320x240::loadMap(void)
             } else if (!mapStyles.empty()) {
                 // populate style dropdown
                 bool savedStyleOK = false;
-                int firstUrlEntry = -1;
-                std::string firstUrl;
-                bool firstHasArchive = false;
                 char savedTileDir[MapTileSettings::TILE_STYLE_SIZE];
                 MapTileSettings::styleToDir(db.uiConfig.map_data.style, savedTileDir, sizeof(savedTileDir));
                 lv_dropdown_clear_options(objects.map_style_dropdown);
@@ -2793,11 +2809,6 @@ void TFTView_320x240::loadMap(void)
                     if (!url.empty()) {
                         urlEntry = TileProvider::addTemplate("URL: " + it, url);
                         lv_dropdown_add_option(objects.map_url_dropdown, std::string("URL: " + it).c_str(), LV_DROPDOWN_POS_LAST);
-                    }
-                    if (it == *mapStyles.begin()) {
-                        firstUrlEntry = urlEntry;
-                        firstUrl = url;
-                        firstHasArchive = hasArchive;
                     }
                     lv_dropdown_add_option(objects.map_style_dropdown, it.c_str(), LV_DROPDOWN_POS_LAST);
                     if (it == savedTileDir) {
@@ -2816,27 +2827,24 @@ void TFTView_320x240::loadMap(void)
                 auto providers = TileProvider::providers();
                 if (!providers.empty()) {
                     lv_dropdown_set_options(objects.map_url_dropdown, providers.c_str());
-                    lv_dropdown_set_selected(objects.map_url_dropdown, TileProvider::selectedTemplate());
                 } else {
                     lv_dropdown_clear_options(objects.map_url_dropdown);
                 }
                 showUrlInputArea(providers.empty());
 
+                char style[MapTileSettings::TILE_STYLE_SIZE];
                 if (!savedStyleOK) {
                     // no such style on SD, pick first one we found
-                    char style[30];
                     lv_dropdown_set_selected(objects.map_style_dropdown, 0);
                     lv_dropdown_get_selected_str(objects.map_style_dropdown, style, sizeof(style));
                     MapTileSettings::setTileStyle(style);
-                    MapTileSettings::setPMTiles(firstHasArchive);
-                    // this fallback style also needs its URL template registered, else fetch silently no-ops
-                    if (firstUrlEntry >= 0) {
-                        ILOG_DEBUG("set provider url to %s", style);
-                        TileProvider::selectTemplate(firstUrlEntry);
-                        lv_dropdown_set_selected(objects.map_url_dropdown, firstUrlEntry);
-                        attribution(firstUrl);
-                    }
                 }
+                else {
+                    strcpy (style, savedTileDir);
+                }
+                std::string url = setUrlProvider(style);
+                if (!url.empty())
+                    savedStyleOK = true;
 
                 MapTileSettings::setSaveOK(savedStyleOK); // allow SD save only for identical style
                 MapTileSettings::setPrefix("/maps");
@@ -2948,6 +2956,38 @@ void TFTView_320x240::attribution(std::string url)
         lv_obj_add_flag(objects.map_attribution_label, LV_OBJ_FLAG_HIDDEN);
     }
 }
+
+std::string TFTView_320x240::setUrlProvider(const char *style)
+{
+    // set url provider if exist
+    char tileDir[MapTileSettings::TILE_STYLE_SIZE];
+    MapTileSettings::styleToDir(style, tileDir, sizeof(tileDir));
+    MapTileSettings::setPMTiles(sdCard && sdCard->hasMapArchive(MapTileSettings::getPrefix(), tileDir));
+    std::string url = sdCard->getUrlProvider(MapTileSettings::getPrefix(), tileDir);
+    if (!url.empty()) {
+        ILOG_DEBUG("set provider url to %s", url.c_str());
+        std::string provider = std::string("URL: ") + style;
+        int entry = TileProvider::addTemplate(provider, url);
+        lv_dropdown_set_selected(objects.map_url_dropdown, entry);
+        TileProvider::selectTemplate(entry);
+        THIS->attribution(url);
+    }
+    else {
+        // no .url found for current style; add a <unset>> field if not exist
+        ILOG_DEBUG("set provider url to %s", _(URL_UNSET));
+        int32_t option = lv_dropdown_get_option_index(objects.map_url_dropdown, _(URL_UNSET));
+        uint32_t entries = lv_dropdown_get_option_count(objects.map_url_dropdown);
+        if (option < 0) {
+            lv_dropdown_add_option(objects.map_url_dropdown, _(URL_UNSET), LV_DROPDOWN_POS_LAST);
+            lv_dropdown_set_selected(objects.map_url_dropdown, entries);
+        }
+        else {
+            lv_dropdown_set_selected(objects.map_url_dropdown, option);
+        }
+    }
+    return url;
+}
+
 
 void TFTView_320x240::ui_event_mesh_detector(lv_event_t *e)
 {

--- a/source/graphics/common/SdCard.cpp
+++ b/source/graphics/common/SdCard.cpp
@@ -215,9 +215,39 @@ std::string SDCard::getUrlProvider(const char *folder, const char *style)
     File file = SDFs.open(filename.c_str(), FILE_READ);
     if (file) {
         String url = file.readStringUntil('\n');
+        url.trim();
         return std::string{url.c_str()};
     }
     return {};
+}
+
+bool SDCard::setUrlProvider(const char *folder, const char *style, const char *urlTemplate)
+{
+    ISpiLock::Guard bus;
+    if (!folder || !style || !urlTemplate)
+        return false;
+    String dir = String(folder) + "/" + String(style);
+    if (!SDFs.exists(folder)) {
+        SDFs.mkdir(folder);
+    }
+    if (!SDFs.exists(dir.c_str())) {
+        if (!SDFs.mkdir(dir.c_str()))
+            return false;
+    }
+    String filename = dir + "/.url";
+    if (SDFs.exists(filename.c_str())) {
+        SDFs.remove(filename.c_str());
+    }
+    File file = SDFs.open(filename.c_str(), FILE_WRITE);
+    if (file) {
+        String cleanUrl = String(urlTemplate);
+        cleanUrl.trim();
+        file.print(cleanUrl);
+        file.print("\n");
+        file.close();
+        return true;
+    }
+    return false;
 }
 
 #elif defined(HAS_SDCARD) && !defined(SENSECAP_INDICATOR)
@@ -393,9 +423,39 @@ std::string SdFsCard::getUrlProvider(const char *folder, const char *style)
     File file = SDFs.open(filename.c_str(), FILE_READ);
     if (file) {
         String url = file.readStringUntil('\n');
+        url.trim();
         return std::string{url.c_str()};
     }
     return {};
+}
+
+bool SdFsCard::setUrlProvider(const char *folder, const char *style, const char *urlTemplate)
+{
+    ISpiLock::Guard bus;
+    if (!folder || !style || !urlTemplate)
+        return false;
+    String dir = String(folder) + "/" + String(style);
+    if (!SDFs.exists(folder)) {
+        SDFs.mkdir(folder);
+    }
+    if (!SDFs.exists(dir.c_str())) {
+        if (!SDFs.mkdir(dir.c_str()))
+            return false;
+    }
+    String filename = dir + "/.url";
+    if (SDFs.exists(filename.c_str())) {
+        SDFs.remove(filename.c_str());
+    }
+    File file = SDFs.open(filename.c_str(), FILE_WRITE);
+    if (file) {
+        String cleanUrl = String(urlTemplate);
+        cleanUrl.trim();
+        file.print(cleanUrl);
+        file.print("\n");
+        file.close();
+        return true;
+    }
+    return false;
 }
 
 #elif defined(SENSECAP_INDICATOR)
@@ -558,6 +618,20 @@ std::string RemoteSdCard::getUrlProvider(const char *folder, const char *style)
     if (nl)
         *nl = '\0';
     return std::string{(char *)buf};
+}
+
+bool RemoteSdCard::setUrlProvider(const char *folder, const char *style, const char *urlTemplate)
+{
+    IRemoteFS *fs = RemoteSDService::backend();
+    if (!fs || !folder || !style || !urlTemplate)
+        return false;
+    std::string filename = std::string(folder) + "/" + style + "/.url";
+    std::string cleanUrl = urlTemplate;
+    while (!cleanUrl.empty() && (cleanUrl.back() == '\r' || cleanUrl.back() == '\n' || cleanUrl.back() == ' ' || cleanUrl.back() == '\t')) {
+        cleanUrl.pop_back();
+    }
+    std::string content = cleanUrl + "\n";
+    return fs->writeChunk(filename.c_str(), 0, (const uint8_t *)content.c_str(), content.size(), true);
 }
 
 #endif // HAS_SDCARD

--- a/source/graphics/common/SdCard.cpp
+++ b/source/graphics/common/SdCard.cpp
@@ -627,7 +627,8 @@ bool RemoteSdCard::setUrlProvider(const char *folder, const char *style, const c
         return false;
     std::string filename = std::string(folder) + "/" + style + "/.url";
     std::string cleanUrl = urlTemplate;
-    while (!cleanUrl.empty() && (cleanUrl.back() == '\r' || cleanUrl.back() == '\n' || cleanUrl.back() == ' ' || cleanUrl.back() == '\t')) {
+    while (!cleanUrl.empty() &&
+           (cleanUrl.back() == '\r' || cleanUrl.back() == '\n' || cleanUrl.back() == ' ' || cleanUrl.back() == '\t')) {
         cleanUrl.pop_back();
     }
     std::string content = cleanUrl + "\n";

--- a/source/graphics/common/SdCard.cpp
+++ b/source/graphics/common/SdCard.cpp
@@ -242,10 +242,9 @@ bool SDCard::setUrlProvider(const char *folder, const char *style, const char *u
     if (file) {
         String cleanUrl = String(urlTemplate);
         cleanUrl.trim();
-        file.print(cleanUrl);
-        file.print("\n");
+        bool written = file.print(cleanUrl) == cleanUrl.length() && file.print("\n") == 1;
         file.close();
-        return true;
+        return written;
     }
     return false;
 }
@@ -450,10 +449,9 @@ bool SdFsCard::setUrlProvider(const char *folder, const char *style, const char 
     if (file) {
         String cleanUrl = String(urlTemplate);
         cleanUrl.trim();
-        file.print(cleanUrl);
-        file.print("\n");
+        bool written = file.print(cleanUrl) == cleanUrl.length() && file.print("\n") == 1;
         file.close();
-        return true;
+        return written;
     }
     return false;
 }
@@ -631,6 +629,9 @@ bool RemoteSdCard::setUrlProvider(const char *folder, const char *style, const c
            (cleanUrl.back() == '\r' || cleanUrl.back() == '\n' || cleanUrl.back() == ' ' || cleanUrl.back() == '\t')) {
         cleanUrl.pop_back();
     }
+    if (cleanUrl.size() > 1023)
+        return false;
+
     std::string content = cleanUrl + "\n";
     return fs->writeChunk(filename.c_str(), 0, (const uint8_t *)content.c_str(), content.size(), true);
 }

--- a/source/graphics/map/MapFileSystem.cpp
+++ b/source/graphics/map/MapFileSystem.cpp
@@ -58,10 +58,8 @@ void SdFatMapFileSystem::close(void)
 
 bool SdFatMapFileSystem::readAt(uint64_t offset, uint8_t *buf, uint32_t len)
 {
-    if (offset > UINT32_MAX)
-        return false;
     ISpiLock::Guard bus;
-    return file && file.seekSet((uint32_t)offset) && file.read(buf, len) == (size_t)len;
+    return file && file.seekSet(offset) && file.read(buf, len) == (size_t)len;
 }
 
 #elif defined(SENSECAP_INDICATOR)
@@ -98,7 +96,7 @@ bool RemoteMapFileSystem::readAt(uint64_t offset, uint8_t *buf, uint32_t len)
 {
     static constexpr uint32_t READ_CHUNK = 4096;
     IRemoteFS *fs = RemoteSDService::backend();
-    if (!fs || !path[0] || offset > UINT32_MAX)
+    if (!fs || !path[0] || offset > UINT64_MAX)
         return false;
 
     uint32_t pos = (uint32_t)offset;

--- a/source/graphics/map/PMTileService.cpp
+++ b/source/graphics/map/PMTileService.cpp
@@ -156,7 +156,7 @@ bool PMTileService::loadFromArchive(uint32_t z, uint32_t x, uint32_t y, void *im
             }
             {
                 if (!archiveFS->readAt(dir_offset, dirBuffer, dir_length)) {
-                    ILOG_ERROR("Failed to read %u bytes of pmtiles directory at %llu", (unsigned int)dir_length,
+                    ILOG_ERROR("Failed to read %u bytes of pmtiles directory at %u", (unsigned int)dir_length,
                                (unsigned long long)dir_offset);
                     lv_free(dirBuffer);
                     return false;

--- a/studio/240x320/TFTView_240x320.eez-project
+++ b/studio/240x320/TFTView_240x320.eez-project
@@ -426,7 +426,8 @@
               "text": "www.meshtastic.org",
               "textType": "literal",
               "longMode": "WRAP",
-              "recolor": false
+              "recolor": false,
+              "useStaticText": true
             },
             {
               "objID": "6df68578-788a-46d6-f321-de6dfb121945",
@@ -471,7 +472,8 @@
               "text": "",
               "textType": "literal",
               "longMode": "WRAP",
-              "recolor": false
+              "recolor": false,
+              "useStaticText": true
             },
             {
               "objID": "09525ee3-85e8-4744-93cb-6c88ddbea6d8",
@@ -861,7 +863,8 @@
                   "text": " www.meshtastic.org",
                   "textType": "literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "6ff01862-ed75-4d17-98cc-2c13d13187e6",
@@ -938,7 +941,8 @@
                       "text": "Reboot into BaseUI?",
                       "textType": "translated-literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "0c3e9fcd-166a-4b2e-bb31-d1711cffbb47",
@@ -1366,7 +1370,8 @@
               "text": "o o o o o o",
               "textType": "literal",
               "longMode": "CLIP",
-              "recolor": false
+              "recolor": false,
+              "useStaticText": true
             }
           ],
           "widgetFlags": "PRESS_LOCK|CLICK_FOCUSABLE|GESTURE_BUBBLE|SNAPPABLE|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER",
@@ -1892,7 +1897,8 @@
                       "text": "no new messages",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "47a3953e-8408-4e95-b63e-c1ee8940fcb1",
@@ -1989,7 +1995,8 @@
                       "text": "1 of 1 nodes online",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "8a223cab-5f8b-46cc-8ffc-99b085c7adf8",
@@ -2086,7 +2093,8 @@
                       "text": "uptime 00:00:00",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "61eb222e-2eb2-4a80-b607-03c53638295a",
@@ -2183,7 +2191,8 @@
                       "text": "LoRa 0.0 MHz",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "71ab0c67-c320-4983-e14a-2d6e59d83b3c",
@@ -2304,7 +2313,8 @@
                           "text": "",
                           "textType": "literal",
                           "longMode": "CLIP",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         }
                       ],
                       "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -2327,7 +2337,8 @@
                       "text": "no signal",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "eabe689b-9868-4924-c018-d7b07062d30c",
@@ -2417,7 +2428,8 @@
                       "text": "silent",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "04fc16da-bba6-431b-e8fa-5de8522ed1a8",
@@ -2514,7 +2526,8 @@
                       "text": "N???° ??.????'\nW???° ??.????'",
                       "textType": "literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "27c1e5fd-3935-4144-916c-1185798b1d0c",
@@ -2605,7 +2618,8 @@
                       "text": "0.0.0.0",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "eb4eacd7-c349-4152-e251-13815fccb611",
@@ -2697,7 +2711,8 @@
                       "text": "0.0.0.0",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "02c6296b-fc7f-4562-cc46-fb8bec506dc1",
@@ -2791,7 +2806,8 @@
                       "text": "00:00:00:00:00:00",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "9bd043ef-141b-43a1-998d-8bba70814790",
@@ -2889,7 +2905,8 @@
                       "text": "mqtt",
                       "textType": "literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "1bf9fa5b-9633-41f4-f677-25223f66356c",
@@ -2986,7 +3003,8 @@
                       "text": "no SD card detected",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "875ff3ef-f5c8-4a74-a56d-14a877d3a00a",
@@ -3085,7 +3103,8 @@
                       "text": "Heap: 0\nLVGL: 0",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "1a9b7e10-3e5b-4173-fead-ed6e1d652de4",
@@ -3183,7 +3202,8 @@
                       "text": "no public key",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "SCROLL_CHAIN|SCROLLABLE|SCROLL_WITH_ARROW",
@@ -3455,7 +3475,8 @@
                       "text": "Meshtastic",
                       "textType": "literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "2df840ee-bd79-4ce1-d706-e8a1cb50401b",
@@ -3502,7 +3523,8 @@
                       "text": "ABCD",
                       "textType": "literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "1ba48a4e-3e33-4a01-b9b4-ada03eb70a78",
@@ -3549,7 +3571,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "f393db90-4ef4-4b03-ab7e-c2d37d10901b",
@@ -3596,7 +3619,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "67873566-79d8-40b7-c7da-44e386340bf0",
@@ -3643,7 +3667,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "f3b76765-4ccf-44d6-eecb-ab7709d6b284",
@@ -3690,7 +3715,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "388a7080-ce7d-43d5-c330-203d649738ec",
@@ -3736,7 +3762,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "353c8ddd-3fac-4d8b-dda4-9efb03e90cb0",
@@ -3783,7 +3810,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "b912e446-6bee-4911-95d1-e50031307882",
@@ -3830,7 +3858,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -3983,7 +4012,8 @@
                       "text": "0",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4076,7 +4106,8 @@
                       "text": "1",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4169,7 +4200,8 @@
                       "text": "2",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4262,7 +4294,8 @@
                       "text": "3",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4355,7 +4388,8 @@
                       "text": "4",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4448,7 +4482,8 @@
                       "text": "5",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4541,7 +4576,8 @@
                       "text": "6",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4634,7 +4670,8 @@
                       "text": "7",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|SCROLL_ELASTIC|SCROLL_ON_FOCUS|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLL_WITH_ARROW",
@@ -4775,7 +4812,8 @@
                       "text": "Text\nLine2 Word2\nLine3",
                       "textType": "literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "PRESS_LOCK|CLICK_FOCUSABLE|GESTURE_BUBBLE|SNAPPABLE|SCROLL_MOMENTUM|SCROLL_CHAIN|SCROLLABLE|SCROLL_ELASTIC|SCROLL_WITH_ARROW",
@@ -5024,7 +5062,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "DOT",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "dd6ff74d-faaf-4d0c-d2b5-5e515eb7576e",
@@ -5094,7 +5133,8 @@
                           "text": "DEL",
                           "textType": "translated-literal",
                           "longMode": "WRAP",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         }
                       ],
                       "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -5913,9 +5953,9 @@
                 {
                   "objID": "24967938-a47f-4deb-e332-508cfcbb7ef1",
                   "type": "LVGLPanelWidget",
-                  "left": 10,
+                  "left": 1,
                   "top": 5,
-                  "width": 80,
+                  "width": 90,
                   "height": 180,
                   "customInputs": [],
                   "customOutputs": [],
@@ -5937,9 +5977,9 @@
                     {
                       "objID": "f4c65a7d-cfeb-46dc-b9bd-3066c2b67927",
                       "type": "LVGLSliderWidget",
-                      "left": 0,
-                      "top": 10,
-                      "width": 85,
+                      "left": -5,
+                      "top": 15,
+                      "width": 80,
                       "height": 8,
                       "customInputs": [],
                       "customOutputs": [],
@@ -6012,9 +6052,9 @@
                     {
                       "objID": "387a5485-a153-4853-b587-6dc2e647a5e9",
                       "type": "LVGLSliderWidget",
-                      "left": 0,
-                      "top": 36,
-                      "width": 85,
+                      "left": -5,
+                      "top": 40,
+                      "width": 80,
                       "height": 8,
                       "customInputs": [],
                       "customOutputs": [],
@@ -6087,9 +6127,9 @@
                     {
                       "objID": "678cc23d-758e-4431-c0c4-1ac63cce52fd",
                       "type": "LVGLDropdownWidget",
-                      "left": 0,
-                      "top": 58,
-                      "width": 85,
+                      "left": -5,
+                      "top": 70,
+                      "width": 80,
                       "height": 27,
                       "customInputs": [],
                       "customOutputs": [],
@@ -6141,14 +6181,15 @@
                       "optionsType": "translated-literal",
                       "selected": 0,
                       "selectedType": "literal",
-                      "direction": "bottom"
+                      "direction": "bottom",
+                      "useStaticText": true
                     },
                     {
                       "objID": "e6199c5b-f0de-4191-9f62-9f6ee2d998e5",
                       "type": "LVGLDropdownWidget",
-                      "left": 0,
-                      "top": 92,
-                      "width": 85,
+                      "left": -5,
+                      "top": 108,
+                      "width": 80,
                       "height": 27,
                       "customInputs": [],
                       "customOutputs": [],
@@ -6196,19 +6237,125 @@
                       },
                       "group": "",
                       "groupIndex": 0,
-                      "options": "Google Maps",
+                      "options": "",
                       "optionsType": "translated-literal",
                       "selected": 0,
                       "selectedType": "literal",
-                      "direction": "bottom"
+                      "direction": "bottom",
+                      "useStaticText": true
+                    },
+                    {
+                      "objID": "52351a9b-c904-49a2-c2f7-602d61172d3b",
+                      "type": "LVGLTextareaWidget",
+                      "left": -5,
+                      "top": 108,
+                      "width": 80,
+                      "height": 27,
+                      "customInputs": [],
+                      "customOutputs": [],
+                      "style": {
+                        "objID": "6344ad96-6797-4ff2-883b-1c171ee642c1",
+                        "useStyle": "default",
+                        "conditionalStyles": [],
+                        "childStyles": []
+                      },
+                      "hiddenInEditor": true,
+                      "timeline": [],
+                      "eventHandlers": [],
+                      "identifier": "mapUrlTextarea",
+                      "leftUnit": "px",
+                      "topUnit": "px",
+                      "widthUnit": "%",
+                      "heightUnit": "px",
+                      "children": [],
+                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SNAPPABLE",
+                      "hiddenFlag": true,
+                      "hiddenFlagType": "literal",
+                      "clickableFlag": true,
+                      "clickableFlagType": "literal",
+                      "flagScrollbarMode": "off",
+                      "checkedStateType": "literal",
+                      "disabledStateType": "literal",
+                      "states": "",
+                      "localStyles": {
+                        "objID": "fe5cc4ee-9272-428a-8023-ef6b09a42b36",
+                        "definition": {
+                          "MAIN": {
+                            "DEFAULT": {
+                              "align": "TOP_MID",
+                              "text_align": "LEFT",
+                              "max_height": 25,
+                              "pad_top": 0,
+                              "pad_bottom": 0,
+                              "pad_left": 3
+                            }
+                          }
+                        }
+                      },
+                      "groupIndex": 0,
+                      "text": "",
+                      "textType": "translated-literal",
+                      "placeholder": "Enter URL template",
+                      "oneLineMode": true,
+                      "passwordMode": false,
+                      "acceptedCharacters": "",
+                      "maxTextLength": 80
+                    },
+                    {
+                      "objID": "0164deba-9dac-4251-dfcf-c8abfe2995c3",
+                      "type": "LVGLButtonWidget",
+                      "left": 190,
+                      "top": 108,
+                      "width": 25,
+                      "height": 25,
+                      "customInputs": [],
+                      "customOutputs": [],
+                      "style": {
+                        "objID": "68f0123f-2733-4a15-c24b-66a888026d08",
+                        "useStyle": "default",
+                        "conditionalStyles": [],
+                        "childStyles": []
+                      },
+                      "hiddenInEditor": true,
+                      "timeline": [],
+                      "eventHandlers": [],
+                      "identifier": "KeyboardButton_12",
+                      "leftUnit": "px",
+                      "topUnit": "px",
+                      "widthUnit": "px",
+                      "heightUnit": "px",
+                      "children": [],
+                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
+                      "hiddenFlag": true,
+                      "hiddenFlagType": "literal",
+                      "clickableFlag": true,
+                      "clickableFlagType": "literal",
+                      "checkedStateType": "literal",
+                      "disabledStateType": "literal",
+                      "states": "",
+                      "localStyles": {
+                        "objID": "a421840d-b225-4c9f-ae1e-7f9b8bd535e7",
+                        "definition": {
+                          "MAIN": {
+                            "DEFAULT": {
+                              "align": "DEFAULT",
+                              "bg_color": "#ffffff",
+                              "bg_img_src": "keyboard_image",
+                              "bg_img_recolor": "#373737",
+                              "bg_img_recolor_opa": 255
+                            }
+                          }
+                        }
+                      },
+                      "groupIndex": 0
                     }
                   ],
-                  "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
+                  "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
                   "hiddenFlag": true,
                   "hiddenFlagType": "literal",
                   "clickableFlag": true,
                   "clickableFlagType": "literal",
-                  "flagScrollbarMode": "",
+                  "flagScrollbarMode": "off",
                   "flagScrollDirection": "",
                   "scrollSnapX": "",
                   "scrollSnapY": "",
@@ -6291,7 +6438,8 @@
                   "text": "",
                   "textType": "literal",
                   "longMode": "SCROLL_CIRCULAR",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "56c54f8b-2d63-46aa-a5aa-58bf9ae78143",
@@ -6308,7 +6456,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": false,
+                  "hiddenInEditor": true,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapAttributionLabel",
@@ -6346,7 +6494,8 @@
                   "text": "",
                   "textType": "literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "9261f80e-a98f-4aaa-9e48-eb92a01b4b27",
@@ -6363,7 +6512,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": false,
+                  "hiddenInEditor": true,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "googleLogoImage",
@@ -6580,7 +6729,8 @@
                               "text": "User name: ",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -6681,7 +6831,8 @@
                               "text": "Region: <Unset>",
                               "textType": "literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -6777,7 +6928,8 @@
                               "text": "Modem Preset: LONG FAST",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -6875,7 +7027,8 @@
                               "text": "Channel: LongFast",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -6971,7 +7124,8 @@
                               "text": "Role: Client",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7067,7 +7221,8 @@
                               "text": "WiFi: <not setup>",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7163,7 +7318,8 @@
                               "text": "Screen Timeout: 60s",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7259,7 +7415,8 @@
                               "text": "Lock: off/off",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7359,7 +7516,8 @@
                               "text": "Screen Brightness: 60%",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7461,7 +7619,8 @@
                               "text": "Theme: Dark",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7563,7 +7722,8 @@
                               "text": "Screen Calibration: default",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7661,7 +7821,8 @@
                               "text": "Input Control: none/none",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7758,7 +7919,8 @@
                               "text": "Message Alert Buzzer: on",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7854,7 +8016,8 @@
                               "text": "Language: English",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -7952,7 +8115,8 @@
                               "text": "Language: English",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8049,7 +8213,8 @@
                               "text": "Configuration Reset",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8145,7 +8310,8 @@
                               "text": "Backup & Restore",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8242,7 +8408,8 @@
                               "text": "Reboot / Shutdown",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8338,7 +8505,8 @@
                               "text": "About / Legal",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8493,7 +8661,8 @@
                               "text": "Mesh Detector",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8598,7 +8767,8 @@
                               "text": "Signal Scanner",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8703,7 +8873,8 @@
                               "text": "Trace Route",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8808,7 +8979,8 @@
                               "text": "Neighbors",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -8913,7 +9085,8 @@
                               "text": "Statistics",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -9018,7 +9191,8 @@
                               "text": "Packet Log",
                               "textType": "translated-literal",
                               "longMode": "DOT",
-                              "recolor": false
+                              "recolor": false,
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -9310,7 +9484,8 @@
                   "text": "Meshtastic",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "",
@@ -9406,7 +9581,8 @@
                   "text": "1 of 1 nodes online",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "41ce5474-bd22-4ef4-9c2d-b9daa8de903f",
@@ -9552,7 +9728,8 @@
                   "text": "Group Channels",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "57788659-92ab-41fc-ff2e-38c2061a5ed5",
@@ -9698,7 +9875,8 @@
                   "text": "no messages",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "c8b11f5a-ac4f-4edb-e007-c889325ccdfa",
@@ -9843,7 +10021,8 @@
                   "text": "Settings & Tools",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "37454560-0bb8-4516-db81-0cffaa96b5e1",
@@ -9988,7 +10167,8 @@
                   "text": "Settings (advanced)",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "797eda32-e5cb-4ed5-ec85-01f2c61fb47e",
@@ -10133,7 +10313,8 @@
                   "text": "Locations Map",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "9daf245e-1ddc-42d9-b346-df46bfdbf5f3",
@@ -10278,7 +10459,8 @@
                   "text": "no chats",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "315601de-2f00-4063-a2b4-81e2bfe6fd3e",
@@ -10423,7 +10605,8 @@
                   "text": "no messages",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "19cd754b-ed5f-4d0e-f8d5-a2a6725988c3",
@@ -10569,7 +10752,8 @@
                   "text": "Node Search",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "27d73816-1cd2-46a3-b24c-7fab50f917b7",
@@ -10714,7 +10898,8 @@
                   "text": "Mesh Detector",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "22364a96-b1ea-4850-d81a-3f663173876f",
@@ -10859,7 +11044,8 @@
                   "text": "About & Attribution",
                   "textType": "translated-literal",
                   "longMode": "DOT",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "e2e590ac-0074-44c4-a961-8ec7b2b75774",
@@ -11005,7 +11191,8 @@
                   "text": "Signal Scanner",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "65df4e3b-b27d-4e66-92d4-2ebacfac9d66",
@@ -11151,7 +11338,8 @@
                   "text": "Trace Route",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "be14c379-b032-4d0a-8674-9189e6e1457b",
@@ -11296,7 +11484,8 @@
                   "text": "Neighbors",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "3a6d5e15-2b22-432e-9ba6-559567b822a4",
@@ -11441,7 +11630,8 @@
                   "text": "Packet Statistics",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "8acad9ae-565e-4e17-e63b-dbd98744e221",
@@ -11586,7 +11776,8 @@
                   "text": "Packet Log",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "a45a5c8c-7d0b-4d2c-b33e-5047d1adef69",
@@ -11731,7 +11922,8 @@
                   "text": "Node Options",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "d7b607dd-a870-4031-bbe9-53f1301a551e",
@@ -11928,7 +12120,8 @@
                   "text": "",
                   "textType": "literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -12022,7 +12215,8 @@
                   "text": "LoRa TX off!",
                   "textType": "translated-literal",
                   "longMode": "DOT",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "15cbea20-9d5a-4a06-db09-11557cbd0437",
@@ -12282,7 +12476,8 @@
                   "text": "Short Name",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "ae79f820-9197-42f3-c5e0-2c4c0eb17bd3",
@@ -12429,7 +12624,8 @@
                   "text": "Long Name",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "09773b9d-2400-42e3-f87d-1ba502e0c0a0",
@@ -12682,7 +12878,8 @@
                   "text": "Primary Channel",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "55363736-bc25-41d3-a54b-da7f83259ff9",
@@ -12757,7 +12954,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -12837,7 +13035,8 @@
                   "text": "Secondary Channels",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "21b31a8e-b6f5-49fd-fb80-429d8ef563b0",
@@ -12912,7 +13111,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13020,7 +13220,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13128,7 +13329,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13236,7 +13438,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13344,7 +13547,8 @@
                       "text": "<unset>",
                       "textType": "literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13452,7 +13656,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13560,7 +13765,8 @@
                       "text": "<unset>",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -13755,7 +13961,8 @@
                   "optionsType": "literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "2fc1b3e5-4138-459f-f103-09b342c35191",
@@ -13906,7 +14113,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "72c2a3cb-73d0-4dbc-842e-382b69c3ca1d",
@@ -13953,7 +14161,8 @@
                   "text": "FrequencySlot: 1 (902.0MHz)",
                   "textType": "literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "50729cce-3d76-4b86-a128-041498103d48",
@@ -14174,7 +14383,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "d5a7d7d6-410f-48a7-9901-5bb75da09a14",
@@ -14321,7 +14531,8 @@
                   "text": "WiFi SSID",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "473306de-4e03-4174-fd7c-0fee09a6ba19",
@@ -14468,7 +14679,8 @@
                   "text": "WiFi pre-shared Key",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "28fd56fa-d212-4e69-8050-241e7ad163f1",
@@ -14718,7 +14930,8 @@
                   "text": "Brightness: 60%",
                   "textType": "translated-literal",
                   "longMode": "SCROLL",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "8f0dcad0-0ecd-443a-83b2-e58af9aba2f1",
@@ -14938,7 +15151,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "4f5a794d-942c-4b3e-e7cb-5ce6f46b7dd3",
@@ -15083,7 +15297,8 @@
                   "text": "Timeout: 60s",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "c1e3e7df-cbc6-474d-bff1-38075dbce018",
@@ -15299,7 +15514,8 @@
                   "text": "Screen Lock",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "32947aa5-a746-4fd4-c357-df78ce36e0ba",
@@ -15407,7 +15623,8 @@
                   "text": "Settings Lock",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "ea12a4ef-7a30-4372-c866-12945619a52a",
@@ -15514,7 +15731,8 @@
                   "text": "Lock PIN",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "2f88e0e3-ab95-4100-aa2f-ff75f1598352",
@@ -15761,7 +15979,8 @@
                   "text": "Mouse",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "aa1027c9-51c7-476f-fc4d-e97a0d6664f2",
@@ -15812,7 +16031,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "07b4545e-1198-4a02-d8d9-4af92bc58f60",
@@ -15858,7 +16078,8 @@
                   "text": "Keyboard",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "b305ebaa-64f2-418f-f386-79069cba0355",
@@ -15909,7 +16130,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "cb8cd115-fa77-4a55-f113-9bfb53bc73ae",
@@ -16054,7 +16276,8 @@
                   "text": "Message Alert",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "4aef1c60-36f1-4f16-c55c-2701c5138b7a",
@@ -16161,7 +16384,8 @@
                   "text": "Ringtone",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "43c31a8c-373c-404c-87df-eb67b7d2bef4",
@@ -16212,7 +16436,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "14efb098-9e37-437c-dc45-93009db80a42",
@@ -16361,7 +16586,8 @@
                   "optionsType": "literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "9af1bbdb-c68b-4bd9-85b8-f08c3389d608",
@@ -16505,7 +16731,8 @@
                   "text": "Zone",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "bccc988f-3eba-4cda-b0e2-af158673343b",
@@ -16556,7 +16783,8 @@
                   "optionsType": "literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "acbaeb9b-cacb-4aa3-89e9-c6ac3050ae0d",
@@ -16602,7 +16830,8 @@
                   "text": "City",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "31717932-0368-4857-d703-4ad8a7381461",
@@ -16653,7 +16882,8 @@
                   "optionsType": "literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "bb7a1cfb-7dcb-409d-e198-0c1178d0755d",
@@ -16802,7 +17032,8 @@
                   "group": "",
                   "groupIndex": 0,
                   "text": "Backup",
-                  "textType": "translated-literal"
+                  "textType": "translated-literal",
+                  "useStaticText": true
                 },
                 {
                   "objID": "a3dfa548-c6ac-4a38-803e-382942674955",
@@ -16852,7 +17083,8 @@
                   "group": "",
                   "groupIndex": 0,
                   "text": "Restore",
-                  "textType": "translated-literal"
+                  "textType": "translated-literal",
+                  "useStaticText": true
                 },
                 {
                   "objID": "34e32ef6-a383-4d3f-8a69-5e1497f17d89",
@@ -16903,7 +17135,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "4622d64a-4dd7-444e-ba06-0aa8f775b485",
@@ -17054,7 +17287,8 @@
                   "optionsType": "translated-literal",
                   "selected": 0,
                   "selectedType": "literal",
-                  "direction": "bottom"
+                  "direction": "bottom",
+                  "useStaticText": true
                 },
                 {
                   "objID": "6c353789-5f46-487c-c16e-cbe4f0f6b87c",
@@ -17203,7 +17437,8 @@
                   "text": "Channel Name",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "9f7b8295-49fc-4e37-e3f2-10d238b38e8c",
@@ -17351,7 +17586,8 @@
                   "text": "Pre-shared Key",
                   "textType": "translated-literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "4f4d4c07-d8e2-4c94-bd33-464baea32d28",
@@ -17926,7 +18162,8 @@
                           "text": "Unknown",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "dd2b665e-a457-443f-f5c9-a8bffcebd97c",
@@ -18040,7 +18277,8 @@
                           "text": "Offline",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "b995bb3a-428b-4054-8c1f-0c03b952edf6",
@@ -18154,7 +18392,8 @@
                           "text": "Public Key",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "e42792bd-6c24-47a9-9279-67414ae8331f",
@@ -18230,7 +18469,8 @@
                               "optionsType": "literal",
                               "selected": 0,
                               "selectedType": "literal",
-                              "direction": "bottom"
+                              "direction": "bottom",
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SNAPPABLE|SCROLLABLE|SCROLL_WITH_ARROW",
@@ -18257,7 +18497,8 @@
                           "text": "Channel",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "9881cec1-40d6-4bdb-85b9-1833363f60b6",
@@ -18333,7 +18574,8 @@
                               "optionsType": "literal",
                               "selected": 0,
                               "selectedType": "literal",
-                              "direction": "bottom"
+                              "direction": "bottom",
+                              "useStaticText": true
                             }
                           ],
                           "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SNAPPABLE|SCROLLABLE|SCROLL_WITH_ARROW",
@@ -18360,7 +18602,8 @@
                           "text": "Hops away",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "6f99c8f8-2dda-4e97-e2b8-08c3f4c05081",
@@ -18475,7 +18718,8 @@
                           "text": "MQTT",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "63cf6bb8-8050-497d-9e2e-b518601cd61e",
@@ -18589,7 +18833,8 @@
                           "text": "Position",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "fa02a295-83c1-4015-ff00-32536af31a87",
@@ -18746,7 +18991,8 @@
                           "text": "Name",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         }
                       ],
                       "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -18915,7 +19161,8 @@
                           "text": "Active Chat",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "3e1b3900-7526-4b10-c092-959a3d25e645",
@@ -19029,7 +19276,8 @@
                           "text": "Position",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "552bb219-e5d6-4ae0-dfed-4806f06bab0e",
@@ -19143,7 +19391,8 @@
                           "text": "Telemetry",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "8cae29ca-2229-455d-ab99-4a78da98f6d1",
@@ -19257,7 +19506,8 @@
                           "text": "IAQ",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         },
                         {
                           "objID": "9f14fcd6-eb6c-4802-fcb9-57f5b6d1940f",
@@ -19414,7 +19664,8 @@
                           "text": "Name",
                           "textType": "translated-literal",
                           "longMode": "DOT",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         }
                       ],
                       "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -19925,7 +20176,8 @@
                   "text": "",
                   "textType": "literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "d8958fcd-6820-47d0-ddf0-30f877ada070",
@@ -20055,7 +20307,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -20179,7 +20432,8 @@
                           "text": "Start",
                           "textType": "translated-literal",
                           "longMode": "WRAP",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         }
                       ],
                       "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -20370,7 +20624,8 @@
                       "text": "",
                       "textType": "literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -20586,7 +20841,8 @@
                       "text": "choose\\nnode",
                       "textType": "translated-literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -20686,7 +20942,8 @@
                       "text": "Start",
                       "textType": "literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -20917,7 +21174,8 @@
                   "text": "SNR\n-10.0",
                   "textType": "literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "7941318f-0287-4f73-be8e-c0d0c7a63d47",
@@ -20968,7 +21226,8 @@
                   "text": "RSSI\n-100",
                   "textType": "literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "86130209-ba90-4e30-a3b9-f519723de170",
@@ -21017,7 +21276,8 @@
                   "text": "8.0\n6.0\n4.0\n2.0\n0.0\n-2.0\n-4.0\n-8.0\n-10.0\n-12.0\n-14.0\n-16.0\n-18.0",
                   "textType": "literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "f035532e-9af4-4641-f482-321899fbb73b",
@@ -21066,7 +21326,8 @@
                   "text": "-20\n-30\n-40\n-50\n-60\n-70\n-80\n-90\n-100\n-110\n-120",
                   "textType": "literal",
                   "longMode": "CLIP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SNAPPABLE",
@@ -21258,7 +21519,8 @@
                       "text": "choose target node",
                       "textType": "translated-literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -21558,7 +21820,8 @@
                           "text": "Start",
                           "textType": "translated-literal",
                           "longMode": "WRAP",
-                          "recolor": false
+                          "recolor": false,
+                          "useStaticText": true
                         }
                       ],
                       "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -21799,7 +22062,8 @@
                       "text": "Meshtastic",
                       "textType": "literal",
                       "longMode": "SCROLL",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "bd886890-dddf-4273-c9b2-0f089dfa3110",
@@ -21847,7 +22111,8 @@
                       "text": "ABCD",
                       "textType": "literal",
                       "longMode": "WRAP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "7cf1d5f2-0a0d-4cf8-a789-f1188241d14d",
@@ -21894,7 +22159,8 @@
                       "text": "100%",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "1533d6b1-5032-4415-a190-2020ae95e31d",
@@ -21941,7 +22207,8 @@
                       "text": "now",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "cd9f8860-6956-4ae0-d21b-85f7e453eb4b",
@@ -21988,7 +22255,8 @@
                       "text": "RSSI: 0.0 SNR: 0.0",
                       "textType": "literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -22381,7 +22649,8 @@
                   "text": "New Message from\n",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -22530,7 +22799,8 @@
                   "text": "Restoring messages ...",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "1c5aeca2-1804-4279-b439-c086d1889450",
@@ -22698,7 +22968,8 @@
                   "text": "Please set region and name",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 },
                 {
                   "objID": "c2988cb4-dc00-468f-92c6-4bcd4d61066e",
@@ -22869,7 +23140,8 @@
                       "text": "Region",
                       "textType": "translated-literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "f8fc2e52-1843-42e8-9799-449e3a8cf93b",
@@ -22920,7 +23192,8 @@
                       "optionsType": "literal",
                       "selected": 0,
                       "selectedType": "literal",
-                      "direction": "bottom"
+                      "direction": "bottom",
+                      "useStaticText": true
                     },
                     {
                       "objID": "12e2631b-fe3a-41d7-ff6d-a12c4e8b0256",
@@ -22969,7 +23242,8 @@
                       "text": "Short Name",
                       "textType": "translated-literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "7a23e411-5430-4774-9c9c-a98eb52bc9dd",
@@ -23116,7 +23390,8 @@
                       "text": "Long Name",
                       "textType": "translated-literal",
                       "longMode": "CLIP",
-                      "recolor": false
+                      "recolor": false,
+                      "useStaticText": true
                     },
                     {
                       "objID": "7b4792e6-d26d-4f0e-a6fe-7692d41eaf26",
@@ -23402,7 +23677,8 @@
                   "text": "Resync ...",
                   "textType": "translated-literal",
                   "longMode": "DOT",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -23602,7 +23878,8 @@
                   "text": "OK",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
@@ -23688,7 +23965,8 @@
                   "text": "Cancel",
                   "textType": "translated-literal",
                   "longMode": "WRAP",
-                  "recolor": false
+                  "recolor": false,
+                  "useStaticText": true
                 }
               ],
               "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",

--- a/studio/240x320/TFTView_240x320.eez-project
+++ b/studio/240x320/TFTView_240x320.eez-project
@@ -5230,7 +5230,7 @@
                 "conditionalStyles": [],
                 "childStyles": []
               },
-              "hiddenInEditor": true,
+              "hiddenInEditor": false,
               "timeline": [],
               "eventHandlers": [],
               "identifier": "MapPanel",
@@ -5254,7 +5254,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "rawMapPanel",
@@ -5278,7 +5278,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "homeLocationImage",
@@ -5326,7 +5326,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "gpsPositionImage",
@@ -5419,7 +5419,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "navigationPanel",
@@ -5443,7 +5443,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowUpButton",
@@ -5493,7 +5493,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowLeftButton",
@@ -5543,7 +5543,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "navButton",
@@ -5593,7 +5593,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowRightButton",
@@ -5643,7 +5643,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowDownButton",
@@ -5729,7 +5729,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "zoomSlider",
@@ -5806,7 +5806,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "gpsLockButton",
@@ -5865,7 +5865,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "zoomInButton",
@@ -5915,7 +5915,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "zoomOutButton",
@@ -5965,7 +5965,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapOSDPanel",
@@ -5989,7 +5989,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapBrightnessSlider",
@@ -6064,7 +6064,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapContrastSlider",
@@ -6139,7 +6139,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapStyleDropdown",
@@ -6199,7 +6199,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapUrlDropdown",
@@ -6245,108 +6245,164 @@
                       "useStaticText": true
                     },
                     {
-                      "objID": "52351a9b-c904-49a2-c2f7-602d61172d3b",
-                      "type": "LVGLTextareaWidget",
-                      "left": -5,
+                      "objID": "6c25124f-8846-4874-e24c-5ba48104840b",
+                      "type": "LVGLPanelWidget",
+                      "left": 5,
                       "top": 108,
-                      "width": 80,
+                      "width": 90,
                       "height": 27,
                       "customInputs": [],
                       "customOutputs": [],
                       "style": {
-                        "objID": "6344ad96-6797-4ff2-883b-1c171ee642c1",
+                        "objID": "97c252da-4c77-4d0c-8f29-e7f8b359d8e5",
                         "useStyle": "default",
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
                       "timeline": [],
                       "eventHandlers": [],
-                      "identifier": "mapUrlTextarea",
+                      "identifier": "mapUrlPanel",
                       "leftUnit": "px",
                       "topUnit": "px",
                       "widthUnit": "%",
                       "heightUnit": "px",
-                      "children": [],
-                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SNAPPABLE",
+                      "children": [
+                        {
+                          "objID": "d1476d2b-fe5f-42c4-ae4c-9d00007a07bb",
+                          "type": "LVGLTextareaWidget",
+                          "left": 0,
+                          "top": 0,
+                          "width": 86,
+                          "height": 27,
+                          "customInputs": [],
+                          "customOutputs": [],
+                          "style": {
+                            "objID": "c6e2cffd-0a5c-4504-a475-4b7a7a2cf9cc",
+                            "useStyle": "default",
+                            "conditionalStyles": [],
+                            "childStyles": []
+                          },
+                          "hiddenInEditor": false,
+                          "timeline": [],
+                          "eventHandlers": [],
+                          "identifier": "mapUrlTextarea",
+                          "leftUnit": "px",
+                          "topUnit": "px",
+                          "widthUnit": "%",
+                          "heightUnit": "px",
+                          "children": [],
+                          "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SNAPPABLE",
+                          "hiddenFlag": false,
+                          "hiddenFlagType": "literal",
+                          "clickableFlag": true,
+                          "clickableFlagType": "literal",
+                          "flagScrollbarMode": "off",
+                          "checkedStateType": "literal",
+                          "disabledStateType": "literal",
+                          "states": "",
+                          "localStyles": {
+                            "objID": "507c9033-bdbf-4f10-9c1d-565b4f22c6e1",
+                            "definition": {
+                              "MAIN": {
+                                "DEFAULT": {
+                                  "pad_top": 0,
+                                  "pad_bottom": 0,
+                                  "align": "LEFT_MID",
+                                  "text_align": "LEFT",
+                                  "max_height": 25,
+                                  "pad_left": 3,
+                                  "pad_right": 3
+                                }
+                              }
+                            }
+                          },
+                          "groupIndex": 0,
+                          "text": "",
+                          "textType": "translated-literal",
+                          "placeholder": "Enter URL template",
+                          "oneLineMode": true,
+                          "passwordMode": false,
+                          "acceptedCharacters": "",
+                          "maxTextLength": 80
+                        },
+                        {
+                          "objID": "0936edad-bc78-4c7d-c046-98f94e69af90",
+                          "type": "LVGLButtonWidget",
+                          "left": 0,
+                          "top": 0,
+                          "width": 25,
+                          "height": 25,
+                          "customInputs": [],
+                          "customOutputs": [],
+                          "style": {
+                            "objID": "6989cabd-fd36-4fe3-86b8-725c234ab2f5",
+                            "useStyle": "default",
+                            "conditionalStyles": [],
+                            "childStyles": []
+                          },
+                          "hiddenInEditor": false,
+                          "timeline": [],
+                          "eventHandlers": [],
+                          "identifier": "KeyboardButton_12",
+                          "leftUnit": "px",
+                          "topUnit": "px",
+                          "widthUnit": "px",
+                          "heightUnit": "px",
+                          "children": [],
+                          "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
+                          "hiddenFlag": false,
+                          "hiddenFlagType": "literal",
+                          "clickableFlag": true,
+                          "clickableFlagType": "literal",
+                          "checkedStateType": "literal",
+                          "disabledStateType": "literal",
+                          "states": "",
+                          "localStyles": {
+                            "objID": "e18a7398-340e-44ae-b200-a0dd9ae2865f",
+                            "definition": {
+                              "MAIN": {
+                                "DEFAULT": {
+                                  "bg_color": "#ffffff",
+                                  "bg_img_src": "keyboard_image",
+                                  "bg_img_recolor": "#373737",
+                                  "bg_img_recolor_opa": 255,
+                                  "align": "RIGHT_MID"
+                                }
+                              }
+                            }
+                          },
+                          "groupIndex": 0
+                        }
+                      ],
+                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
                       "hiddenFlag": true,
                       "hiddenFlagType": "literal",
                       "clickableFlag": true,
                       "clickableFlagType": "literal",
-                      "flagScrollbarMode": "off",
+                      "flagScrollbarMode": "",
+                      "flagScrollDirection": "",
+                      "scrollSnapX": "",
+                      "scrollSnapY": "",
                       "checkedStateType": "literal",
                       "disabledStateType": "literal",
                       "states": "",
                       "localStyles": {
-                        "objID": "fe5cc4ee-9272-428a-8023-ef6b09a42b36",
+                        "objID": "94fc26cc-bd40-40c2-b5d5-4cd2e4b004f8",
                         "definition": {
                           "MAIN": {
                             "DEFAULT": {
                               "align": "TOP_MID",
-                              "text_align": "LEFT",
-                              "max_height": 25,
                               "pad_top": 0,
                               "pad_bottom": 0,
-                              "pad_left": 3
+                              "pad_left": 0,
+                              "pad_right": 0,
+                              "border_width": 0,
+                              "bg_opa": 0
                             }
                           }
                         }
                       },
-                      "groupIndex": 0,
-                      "text": "",
-                      "textType": "translated-literal",
-                      "placeholder": "Enter URL template",
-                      "oneLineMode": true,
-                      "passwordMode": false,
-                      "acceptedCharacters": "",
-                      "maxTextLength": 80
-                    },
-                    {
-                      "objID": "0164deba-9dac-4251-dfcf-c8abfe2995c3",
-                      "type": "LVGLButtonWidget",
-                      "left": 190,
-                      "top": 108,
-                      "width": 25,
-                      "height": 25,
-                      "customInputs": [],
-                      "customOutputs": [],
-                      "style": {
-                        "objID": "68f0123f-2733-4a15-c24b-66a888026d08",
-                        "useStyle": "default",
-                        "conditionalStyles": [],
-                        "childStyles": []
-                      },
-                      "hiddenInEditor": true,
-                      "timeline": [],
-                      "eventHandlers": [],
-                      "identifier": "KeyboardButton_12",
-                      "leftUnit": "px",
-                      "topUnit": "px",
-                      "widthUnit": "px",
-                      "heightUnit": "px",
-                      "children": [],
-                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
-                      "hiddenFlag": true,
-                      "hiddenFlagType": "literal",
-                      "clickableFlag": true,
-                      "clickableFlagType": "literal",
-                      "checkedStateType": "literal",
-                      "disabledStateType": "literal",
-                      "states": "",
-                      "localStyles": {
-                        "objID": "a421840d-b225-4c9f-ae1e-7f9b8bd535e7",
-                        "definition": {
-                          "MAIN": {
-                            "DEFAULT": {
-                              "align": "DEFAULT",
-                              "bg_color": "#ffffff",
-                              "bg_img_src": "keyboard_image",
-                              "bg_img_recolor": "#373737",
-                              "bg_img_recolor_opa": 255
-                            }
-                          }
-                        }
-                      },
+                      "group": "",
                       "groupIndex": 0
                     }
                   ],
@@ -6400,7 +6456,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapLocationLabel",
@@ -6456,7 +6512,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapAttributionLabel",
@@ -6512,7 +6568,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "googleLogoImage",

--- a/studio/320x240/TFT320x240.eez-project
+++ b/studio/320x240/TFT320x240.eez-project
@@ -5530,9 +5530,9 @@
                 {
                   "objID": "4764d222-a494-48ed-bad2-efd58fbe7a8b",
                   "type": "LVGLPanelWidget",
-                  "left": 0,
+                  "left": -15,
                   "top": 5,
-                  "width": 80,
+                  "width": 89,
                   "height": 180,
                   "customInputs": [],
                   "customOutputs": [],
@@ -5556,7 +5556,7 @@
                       "type": "LVGLSliderWidget",
                       "left": 0,
                       "top": 10,
-                      "width": 85,
+                      "width": 78,
                       "height": 8,
                       "customInputs": [],
                       "customOutputs": [],
@@ -5631,7 +5631,7 @@
                       "type": "LVGLSliderWidget",
                       "left": 0,
                       "top": 36,
-                      "width": 85,
+                      "width": 78,
                       "height": 8,
                       "customInputs": [],
                       "customOutputs": [],
@@ -5706,7 +5706,7 @@
                       "type": "LVGLDropdownWidget",
                       "left": 0,
                       "top": 58,
-                      "width": 85,
+                      "width": 78,
                       "height": 27,
                       "customInputs": [],
                       "customOutputs": [],
@@ -5766,7 +5766,7 @@
                       "type": "LVGLDropdownWidget",
                       "left": 0,
                       "top": 92,
-                      "width": 85,
+                      "width": 78,
                       "height": 27,
                       "customInputs": [],
                       "customOutputs": [],
@@ -5814,12 +5814,117 @@
                       },
                       "group": "",
                       "groupIndex": 0,
-                      "options": "Google Maps",
+                      "options": "",
                       "optionsType": "translated-literal",
                       "selected": 0,
                       "selectedType": "literal",
                       "direction": "bottom",
                       "useStaticText": true
+                    },
+                    {
+                      "objID": "6ab0be84-23b6-49d1-f88f-008898459fd0",
+                      "type": "LVGLTextareaWidget",
+                      "left": 0,
+                      "top": 92,
+                      "width": 78,
+                      "height": 27,
+                      "customInputs": [],
+                      "customOutputs": [],
+                      "style": {
+                        "objID": "4eddd69e-fc17-409c-8b55-a3ae9a8496bb",
+                        "useStyle": "default",
+                        "conditionalStyles": [],
+                        "childStyles": []
+                      },
+                      "hiddenInEditor": true,
+                      "timeline": [],
+                      "eventHandlers": [],
+                      "identifier": "mapUrlTextarea",
+                      "leftUnit": "px",
+                      "topUnit": "px",
+                      "widthUnit": "%",
+                      "heightUnit": "px",
+                      "children": [],
+                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SNAPPABLE",
+                      "hiddenFlag": true,
+                      "hiddenFlagType": "literal",
+                      "clickableFlag": true,
+                      "clickableFlagType": "literal",
+                      "flagScrollbarMode": "off",
+                      "checkedStateType": "literal",
+                      "disabledStateType": "literal",
+                      "states": "",
+                      "localStyles": {
+                        "objID": "6a59a55e-e56c-4455-8e65-6db3b5b8526d",
+                        "definition": {
+                          "MAIN": {
+                            "DEFAULT": {
+                              "pad_top": 0,
+                              "pad_bottom": 0,
+                              "align": "TOP_MID",
+                              "text_align": "LEFT",
+                              "max_height": 25,
+                              "pad_left": 3
+                            }
+                          }
+                        }
+                      },
+                      "groupIndex": 0,
+                      "text": "",
+                      "textType": "translated-literal",
+                      "placeholder": "Enter URL template",
+                      "oneLineMode": true,
+                      "passwordMode": false,
+                      "acceptedCharacters": "",
+                      "maxTextLength": 80
+                    },
+                    {
+                      "objID": "da4fac8e-556c-47d9-ed78-767cb7ebfef6",
+                      "type": "LVGLButtonWidget",
+                      "left": 224,
+                      "top": 92,
+                      "width": 25,
+                      "height": 25,
+                      "customInputs": [],
+                      "customOutputs": [],
+                      "style": {
+                        "objID": "4fbd3be4-cec6-42e2-9c32-4c1bc8ec7ea5",
+                        "useStyle": "default",
+                        "conditionalStyles": [],
+                        "childStyles": []
+                      },
+                      "hiddenInEditor": true,
+                      "timeline": [],
+                      "eventHandlers": [],
+                      "identifier": "KeyboardButton_12",
+                      "leftUnit": "px",
+                      "topUnit": "px",
+                      "widthUnit": "px",
+                      "heightUnit": "px",
+                      "children": [],
+                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
+                      "hiddenFlag": false,
+                      "hiddenFlagType": "literal",
+                      "clickableFlag": true,
+                      "clickableFlagType": "literal",
+                      "checkedStateType": "literal",
+                      "disabledStateType": "literal",
+                      "states": "",
+                      "localStyles": {
+                        "objID": "41c8ad35-d5c3-4488-a140-bec09fd92cb5",
+                        "definition": {
+                          "MAIN": {
+                            "DEFAULT": {
+                              "align": "DEFAULT",
+                              "bg_color": "#ffffff",
+                              "bg_img_src": "keyboard_image",
+                              "bg_img_recolor": "#373737",
+                              "bg_img_recolor_opa": 255
+                            }
+                          }
+                        }
+                      },
+                      "groupIndex": 0
                     }
                   ],
                   "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",

--- a/studio/320x240/TFT320x240.eez-project
+++ b/studio/320x240/TFT320x240.eez-project
@@ -4807,7 +4807,7 @@
                 "conditionalStyles": [],
                 "childStyles": []
               },
-              "hiddenInEditor": true,
+              "hiddenInEditor": false,
               "timeline": [],
               "eventHandlers": [],
               "identifier": "MapPanel",
@@ -4831,7 +4831,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "rawMapPanel",
@@ -4855,7 +4855,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "homeLocationImage",
@@ -4903,7 +4903,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "gpsPositionImage",
@@ -4996,7 +4996,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "navigationPanel",
@@ -5020,7 +5020,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowUpButton",
@@ -5070,7 +5070,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowLeftButton",
@@ -5120,7 +5120,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "navButton",
@@ -5170,7 +5170,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowRightButton",
@@ -5220,7 +5220,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "arrowDownButton",
@@ -5306,7 +5306,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "zoomSlider",
@@ -5383,7 +5383,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "gpsLockButton",
@@ -5442,7 +5442,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "zoomInButton",
@@ -5492,7 +5492,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "zoomOutButton",
@@ -5542,7 +5542,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapOSDPanel",
@@ -5566,7 +5566,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapBrightnessSlider",
@@ -5641,7 +5641,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapContrastSlider",
@@ -5716,7 +5716,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapStyleDropdown",
@@ -5776,7 +5776,7 @@
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
+                      "hiddenInEditor": false,
                       "timeline": [],
                       "eventHandlers": [],
                       "identifier": "mapUrlDropdown",
@@ -5822,8 +5822,8 @@
                       "useStaticText": true
                     },
                     {
-                      "objID": "6ab0be84-23b6-49d1-f88f-008898459fd0",
-                      "type": "LVGLTextareaWidget",
+                      "objID": "1599970c-7a7e-4ca8-b29d-5cdf1997284e",
+                      "type": "LVGLPanelWidget",
                       "left": 0,
                       "top": 92,
                       "width": 78,
@@ -5831,99 +5831,154 @@
                       "customInputs": [],
                       "customOutputs": [],
                       "style": {
-                        "objID": "4eddd69e-fc17-409c-8b55-a3ae9a8496bb",
+                        "objID": "c496012b-4cea-4c06-8abc-c524b75cbdcb",
                         "useStyle": "default",
                         "conditionalStyles": [],
                         "childStyles": []
                       },
-                      "hiddenInEditor": true,
                       "timeline": [],
                       "eventHandlers": [],
-                      "identifier": "mapUrlTextarea",
+                      "identifier": "mapUrlPanel",
                       "leftUnit": "px",
                       "topUnit": "px",
                       "widthUnit": "%",
                       "heightUnit": "px",
-                      "children": [],
-                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SNAPPABLE",
-                      "hiddenFlag": true,
+                      "children": [
+                        {
+                          "objID": "6ab0be84-23b6-49d1-f88f-008898459fd0",
+                          "type": "LVGLTextareaWidget",
+                          "left": 0,
+                          "top": 0,
+                          "width": 87,
+                          "height": 27,
+                          "customInputs": [],
+                          "customOutputs": [],
+                          "style": {
+                            "objID": "4eddd69e-fc17-409c-8b55-a3ae9a8496bb",
+                            "useStyle": "default",
+                            "conditionalStyles": [],
+                            "childStyles": []
+                          },
+                          "hiddenInEditor": false,
+                          "timeline": [],
+                          "eventHandlers": [],
+                          "identifier": "mapUrlTextarea",
+                          "leftUnit": "px",
+                          "topUnit": "px",
+                          "widthUnit": "%",
+                          "heightUnit": "px",
+                          "children": [],
+                          "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLLABLE|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SNAPPABLE",
+                          "hiddenFlag": false,
+                          "hiddenFlagType": "literal",
+                          "clickableFlag": true,
+                          "clickableFlagType": "literal",
+                          "flagScrollbarMode": "off",
+                          "checkedStateType": "literal",
+                          "disabledStateType": "literal",
+                          "states": "",
+                          "localStyles": {
+                            "objID": "6a59a55e-e56c-4455-8e65-6db3b5b8526d",
+                            "definition": {
+                              "MAIN": {
+                                "DEFAULT": {
+                                  "pad_top": 0,
+                                  "pad_bottom": 0,
+                                  "align": "LEFT_MID",
+                                  "text_align": "LEFT",
+                                  "max_height": 25,
+                                  "pad_left": 3,
+                                  "pad_right": 3
+                                }
+                              }
+                            }
+                          },
+                          "groupIndex": 0,
+                          "text": "",
+                          "textType": "translated-literal",
+                          "placeholder": "Enter URL template",
+                          "oneLineMode": true,
+                          "passwordMode": false,
+                          "acceptedCharacters": "",
+                          "maxTextLength": 80
+                        },
+                        {
+                          "objID": "da4fac8e-556c-47d9-ed78-767cb7ebfef6",
+                          "type": "LVGLButtonWidget",
+                          "left": 0,
+                          "top": 0,
+                          "width": 25,
+                          "height": 25,
+                          "customInputs": [],
+                          "customOutputs": [],
+                          "style": {
+                            "objID": "4fbd3be4-cec6-42e2-9c32-4c1bc8ec7ea5",
+                            "useStyle": "default",
+                            "conditionalStyles": [],
+                            "childStyles": []
+                          },
+                          "hiddenInEditor": false,
+                          "timeline": [],
+                          "eventHandlers": [],
+                          "identifier": "KeyboardButton_12",
+                          "leftUnit": "px",
+                          "topUnit": "px",
+                          "widthUnit": "px",
+                          "heightUnit": "px",
+                          "children": [],
+                          "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
+                          "hiddenFlag": false,
+                          "hiddenFlagType": "literal",
+                          "clickableFlag": true,
+                          "clickableFlagType": "literal",
+                          "checkedStateType": "literal",
+                          "disabledStateType": "literal",
+                          "states": "",
+                          "localStyles": {
+                            "objID": "41c8ad35-d5c3-4488-a140-bec09fd92cb5",
+                            "definition": {
+                              "MAIN": {
+                                "DEFAULT": {
+                                  "bg_color": "#ffffff",
+                                  "bg_img_src": "keyboard_image",
+                                  "bg_img_recolor": "#373737",
+                                  "bg_img_recolor_opa": 255,
+                                  "align": "RIGHT_MID"
+                                }
+                              }
+                            }
+                          },
+                          "groupIndex": 0
+                        }
+                      ],
+                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_WITH_ARROW|SNAPPABLE",
                       "hiddenFlagType": "literal",
                       "clickableFlag": true,
                       "clickableFlagType": "literal",
-                      "flagScrollbarMode": "off",
+                      "flagScrollbarMode": "",
+                      "flagScrollDirection": "",
+                      "scrollSnapX": "",
+                      "scrollSnapY": "",
                       "checkedStateType": "literal",
                       "disabledStateType": "literal",
                       "states": "",
                       "localStyles": {
-                        "objID": "6a59a55e-e56c-4455-8e65-6db3b5b8526d",
+                        "objID": "4ac3f360-08f0-4111-9382-db83f6a0a80a",
                         "definition": {
                           "MAIN": {
                             "DEFAULT": {
+                              "align": "TOP_MID",
                               "pad_top": 0,
                               "pad_bottom": 0,
-                              "align": "TOP_MID",
-                              "text_align": "LEFT",
-                              "max_height": 25,
-                              "pad_left": 3
+                              "pad_left": 0,
+                              "pad_right": 0,
+                              "border_width": 0,
+                              "bg_opa": 0
                             }
                           }
                         }
                       },
-                      "groupIndex": 0,
-                      "text": "",
-                      "textType": "translated-literal",
-                      "placeholder": "Enter URL template",
-                      "oneLineMode": true,
-                      "passwordMode": false,
-                      "acceptedCharacters": "",
-                      "maxTextLength": 80
-                    },
-                    {
-                      "objID": "da4fac8e-556c-47d9-ed78-767cb7ebfef6",
-                      "type": "LVGLButtonWidget",
-                      "left": 224,
-                      "top": 92,
-                      "width": 25,
-                      "height": 25,
-                      "customInputs": [],
-                      "customOutputs": [],
-                      "style": {
-                        "objID": "4fbd3be4-cec6-42e2-9c32-4c1bc8ec7ea5",
-                        "useStyle": "default",
-                        "conditionalStyles": [],
-                        "childStyles": []
-                      },
-                      "hiddenInEditor": true,
-                      "timeline": [],
-                      "eventHandlers": [],
-                      "identifier": "KeyboardButton_12",
-                      "leftUnit": "px",
-                      "topUnit": "px",
-                      "widthUnit": "px",
-                      "heightUnit": "px",
-                      "children": [],
-                      "widgetFlags": "CLICK_FOCUSABLE|GESTURE_BUBBLE|PRESS_LOCK|SCROLL_CHAIN_HOR|SCROLL_CHAIN_VER|SCROLL_ELASTIC|SCROLL_MOMENTUM|SCROLL_ON_FOCUS|SCROLL_WITH_ARROW|SNAPPABLE",
-                      "hiddenFlag": false,
-                      "hiddenFlagType": "literal",
-                      "clickableFlag": true,
-                      "clickableFlagType": "literal",
-                      "checkedStateType": "literal",
-                      "disabledStateType": "literal",
-                      "states": "",
-                      "localStyles": {
-                        "objID": "41c8ad35-d5c3-4488-a140-bec09fd92cb5",
-                        "definition": {
-                          "MAIN": {
-                            "DEFAULT": {
-                              "align": "DEFAULT",
-                              "bg_color": "#ffffff",
-                              "bg_img_src": "keyboard_image",
-                              "bg_img_recolor": "#373737",
-                              "bg_img_recolor_opa": 255
-                            }
-                          }
-                        }
-                      },
+                      "group": "",
                       "groupIndex": 0
                     }
                   ],
@@ -5954,7 +6009,9 @@
                           "pad_left": 0,
                           "pad_right": 0,
                           "pad_row": 2,
-                          "pad_column": 2
+                          "pad_column": 8,
+                          "grid_row_dsc_array": "",
+                          "grid_column_dsc_array": ""
                         }
                       }
                     }
@@ -5977,7 +6034,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapLocationLabel",
@@ -6033,7 +6090,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "mapAttributionLabel",
@@ -6089,7 +6146,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": true,
+                  "hiddenInEditor": false,
                   "timeline": [],
                   "eventHandlers": [],
                   "identifier": "googleLogoImage",


### PR DESCRIPTION
Allows to edit the download URL template in the map options panel:
- select an already selected style from the dropdown and its URL can be edited
- for unset URLs click the URL dropdown and select _URL: \<unset\>_

Note: the [URL template](https://wiki.openstreetmap.org/wiki/Raster_tile_providers) must contain all three `{z}/{x}/{y}` placeholders otherwise it will be rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for entering, validating, and saving custom map tile URL templates.
  * Added support for self-hosted Protomaps tile sources and PMTiles configurations.
  * Saved URL templates can be reused from supported storage locations.

* **UI Updates**
  * Updated map panels with URL input controls and keyboard support.
  * Improved map style and URL selection behavior.

* **Bug Fixes**
  * Improved URL template storage validation and reporting.
  * Prevented stale URL values from being submitted after changing selections.

* **Documentation**
  * Added self-hosting instructions for Protomaps.
  * Expanded device compatibility information and clarified colored map support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->