### PR TITLE
fix: include <atomic> in SerialClient.h

### DIFF
--- a/include/comms/SerialClient.h
+++ b/include/comms/SerialClient.h
@@ -4,11 +4,11 @@
 #include "comms/IClientBase.h"
 #include "comms/MeshEnvelope.h"
 #include "util/SharedQueue.h"
+#include <atomic>
 #if defined(HAS_FREE_RTOS) || defined(ARCH_ESP32) || defined(ARDUINO_ARCH_ESP32)
 #include "freertos/task.h"
 #endif
 #ifdef ARCH_PORTDUINO
-#include <atomic>
 #include <thread>
 #endif
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal header inclusion handling to support consistent builds across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->