### PR TITLE
fix: battery level 100%

### DIFF
--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -5276,18 +5276,18 @@ void TFTView_320x240::updateMetrics(uint32_t nodeNum, uint32_t bat_level, float 
 
             // update battery percentage and symbol
             if (bat_level != 0 || voltage != 0) {
-                uint32_t shown_level = std::min(bat_level, (uint32_t)100);
-                sprintf(buf, "%d%%", shown_level);
-                bool alert = false;
+                if (bat_level <= 100)
+                    sprintf(buf, "%d%%", bat_level);
+                else
+                    buf[0] = '\0';
 
+                bool alert = false;
                 BatteryLevel level;
                 BatteryLevel::Status status = level.calcStatus(bat_level, voltage);
                 switch (status) {
                 case BatteryLevel::Plugged:
                     lv_obj_set_style_bg_image_src(objects.battery_image, &img_battery_plug_image,
                                                   LV_PART_MAIN | LV_STATE_DEFAULT);
-                    if (shown_level == 100)
-                        buf[0] = '\0';
                     break;
                 case BatteryLevel::Charging:
                     lv_obj_set_style_bg_image_src(objects.battery_image, &img_battery_bolt_image,
@@ -5324,8 +5324,11 @@ void TFTView_320x240::updateMetrics(uint32_t nodeNum, uint32_t bat_level, float 
         }
 
         if (bat_level != 0 || voltage != 0) {
-            bat_level = std::min(bat_level, (uint32_t)100);
-            sprintf(buf, "%d%% %0.2fV", bat_level, voltage);
+            if (bat_level > 100) {
+                sprintf(buf, "%0.2fV", voltage);
+            } else {
+                sprintf(buf, "%d%% %0.2fV", bat_level, voltage);
+            }
             lv_label_set_text(it->second->LV_OBJ_IDX(node_bat_idx), buf);
             lv_obj_remove_flag(it->second->LV_OBJ_IDX(node_bat_idx), LV_OBJ_FLAG_HIDDEN);
         }

--- a/source/graphics/common/BatteryLevel.cpp
+++ b/source/graphics/common/BatteryLevel.cpp
@@ -18,7 +18,7 @@ BatteryLevel::Status BatteryLevel::calcStatus(uint32_t percentage, float voltage
     if (voltage == levels[Plugged].voltage) {
         return Plugged;
     }
-    if (percentage >= levels[Charging].percentage && voltage > levels[Charging].voltage) {
+    if (percentage > levels[Charging].percentage) {
         return Charging;
     } else if (percentage >= levels[Full].percentage && voltage > levels[Full].voltage) {
         return Full;


### PR DESCRIPTION
- removes the 100% label while charging
- properly show charge icon when charging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Battery readings above 100% no longer display an incorrect “100%” value.
  - For readings above 100%, battery details show the voltage without an invalid percentage.
  - Fully charged batteries remain labeled appropriately while plugged in.
  - Charging status is now determined by the battery percentage threshold, improving status accuracy when voltage readings vary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->