### PR TITLE
feat: use FatFS instead of FS to allow uint64_t seek functions

### DIFF
--- a/include/graphics/map/MapFileSystem.h
+++ b/include/graphics/map/MapFileSystem.h
@@ -22,15 +22,28 @@ class IMapFileSystem
 #include "graphics/common/SdCard.h"
 #endif
 
+// On SDIO the archive is read through FatFs instead of the VFS: fs::File::seek()
+// takes a uint32_t and ends in fseek(long), so exFAT offsets past 2 GiB fail.
+#if defined(HAS_SD_MMC) && !defined(ARCH_PORTDUINO)
+#define MAPFILE_USE_FATFS 1
+#endif
+
 class SDMapFileSystem : public IMapFileSystem
 {
   public:
     bool open(const char *path) override;
     void close(void) override;
     bool readAt(uint64_t offset, uint8_t *buf, uint32_t len) override;
+#ifdef MAPFILE_USE_FATFS
+    ~SDMapFileSystem(void) override { close(); }
+#endif
 
   private:
+#ifdef MAPFILE_USE_FATFS
+    void *fil = nullptr; // FatFs FIL, kept opaque so ff.h stays out of this header
+#else
     File file;
+#endif
 };
 
 #elif defined(HAS_SDCARD) && !defined(SENSECAP_INDICATOR)

--- a/source/graphics/common/SdCard.cpp
+++ b/source/graphics/common/SdCard.cpp
@@ -78,6 +78,11 @@ SDCard::~SDCard(void) {}
 
 #elif defined(HAS_SD_MMC) && !defined(SENSECAP_INDICATOR)
 
+#include "ff.h"
+
+// the card is FatFs drive 0; SDMMCFS itself assumes the same in totalBytes()
+#define SDCARD_FATFS_DRIVE "0:"
+
 bool SDCard::init(void)
 {
     ISpiLock::Guard bus;
@@ -101,7 +106,9 @@ ISdCard::CardType SDCard::cardType(void)
     case CARD_SD:
         return CardType::eSD;
     case CARD_SDHC:
-        return CardType::eSDHC;
+        // SDMMCFS reports SDHC for anything with the SDHC capability bit, which
+        // SDXC sets as well; only the capacity separates them
+        return SDFs.cardSize() > 32Ull * 1024Ull * 1024Ull * 1024Ull ? CardType::eSDXC : CardType::eSDHC;
     case CARD_UNKNOWN:
     default:
         return CardType::eUnknown;
@@ -112,7 +119,21 @@ ISdCard::CardType SDCard::cardType(void)
 ISdCard::FatType SDCard::fatType(void)
 {
     ISpiLock::Guard bus;
-    return SDFs.cardSize() > 4Ull * 1024Ull * 1024Ull * 1024Ull ? FatType::eFat32 : FatType::eFat16;
+    FATFS *fs = nullptr;
+    DWORD freeClusters = 0;
+    if (f_getfree(SDCARD_FATFS_DRIVE, &freeClusters, &fs) != FR_OK || !fs)
+        return FatType::eNA;
+    switch (fs->fs_type) {
+    case FS_FAT12:
+    case FS_FAT16:
+        return FatType::eFat16;
+    case FS_FAT32:
+        return FatType::eFat32;
+    case FS_EXFAT:
+        return FatType::eExFat;
+    default:
+        return FatType::eNA;
+    }
 }
 
 ISdCard::ErrorType SDCard::errorType(void)

--- a/source/graphics/map/MapFileSystem.cpp
+++ b/source/graphics/map/MapFileSystem.cpp
@@ -162,7 +162,8 @@ bool RemoteMapFileSystem::readAt(uint64_t offset, uint8_t *buf, uint32_t len)
     static constexpr uint32_t READ_CHUNK = 4096;
     IRemoteFS *fs = RemoteSDService::backend();
     // the remote protocol addresses chunks with a uint32_t offset
-    if (!fs || !path[0] || offset > UINT32_MAX)
+    constexpr uint64_t ADDRESS_SPACE_SIZE = uint64_t{UINT32_MAX} + 1;
+    if (!fs || !path[0] || offset > UINT32_MAX || len > ADDRESS_SPACE_SIZE - offset)
         return false;
 
     uint32_t pos = (uint32_t)offset;

--- a/source/graphics/map/MapFileSystem.cpp
+++ b/source/graphics/map/MapFileSystem.cpp
@@ -7,6 +7,68 @@
 
 #if (defined(ARCH_PORTDUINO) || defined(HAS_SD_MMC) || defined(SDCARD_SHARE_SPI)) && !defined(SENSECAP_INDICATOR)
 
+#if defined(MAPFILE_USE_FATFS)
+
+#include "ff.h"
+#include <cstdlib>
+#include <string>
+
+// SD_MMC mounts the card as FatFs drive 0; SDMMCFS itself assumes the same
+#define MAPFILE_FATFS_DRIVE "0:"
+
+bool SDMapFileSystem::open(const char *path)
+{
+    ISpiLock::Guard bus;
+    if (fil) {
+        f_close((FIL *)fil);
+        free(fil);
+        fil = nullptr;
+    }
+    if (!path)
+        return false;
+
+    // FIL embeds a FF_MAX_SS sector cache (4 KB here), so it never goes on the stack
+    FIL *f = (FIL *)malloc(sizeof(FIL));
+    if (!f)
+        return false;
+
+    std::string volpath = std::string(MAPFILE_FATFS_DRIVE) + path;
+    if (f_open(f, volpath.c_str(), FA_READ) != FR_OK) {
+        free(f);
+        return false;
+    }
+    fil = f;
+    return true;
+}
+
+void SDMapFileSystem::close(void)
+{
+    ISpiLock::Guard bus;
+    if (fil) {
+        f_close((FIL *)fil);
+        free(fil);
+        fil = nullptr;
+    }
+}
+
+bool SDMapFileSystem::readAt(uint64_t offset, uint8_t *buf, uint32_t len)
+{
+    ISpiLock::Guard bus;
+    if (!fil)
+        return false;
+    // FSIZE_t is 32 bit unless FatFs was built with exFAT; folds away when it is 64
+    if (offset > (uint64_t)(FSIZE_t)-1)
+        return false;
+    FIL *f = (FIL *)fil;
+    // f_lseek clamps past EOF instead of failing, so confirm where we landed
+    if (f_lseek(f, (FSIZE_t)offset) != FR_OK || (uint64_t)f_tell(f) != offset)
+        return false;
+    UINT read = 0;
+    return f_read(f, buf, len, &read) == FR_OK && read == len;
+}
+
+#else
+
 #if defined(SDCARD_SHARE_SPI) && !defined(ARCH_PORTDUINO) && !defined(HAS_SD_MMC)
 #include "SD.h"
 #define MAPFILE_OPEN(path) SD.open(path, FILE_READ)
@@ -32,11 +94,14 @@ void SDMapFileSystem::close(void)
 
 bool SDMapFileSystem::readAt(uint64_t offset, uint8_t *buf, uint32_t len)
 {
-    if (offset > UINT32_MAX)
+    // seek() is uint32_t and ends in fseek(long), so this tops out at 2 GiB
+    if (offset > INT32_MAX)
         return false;
     ISpiLock::Guard bus;
     return file && file.seek((uint32_t)offset) && file.read(buf, len) == (size_t)len;
 }
+
+#endif // MAPFILE_USE_FATFS
 
 #elif defined(HAS_SDCARD) && !defined(SENSECAP_INDICATOR)
 
@@ -96,7 +161,8 @@ bool RemoteMapFileSystem::readAt(uint64_t offset, uint8_t *buf, uint32_t len)
 {
     static constexpr uint32_t READ_CHUNK = 4096;
     IRemoteFS *fs = RemoteSDService::backend();
-    if (!fs || !path[0] || offset > UINT64_MAX)
+    // the remote protocol addresses chunks with a uint32_t offset
+    if (!fs || !path[0] || offset > UINT32_MAX)
         return false;
 
     uint32_t pos = (uint32_t)offset;


### PR DESCRIPTION
exFat requires uint64_t functions which are not supported by Arduino FS.
These will be used by SD drivers not supported by SdFat library (i.e. SDIO).

Note: use of esp-idf exFat requires setting of hard-coded `FF_FS_EXFAT` to 1 which can be achieved by using an extra script `esp32_fatfs_exfat.py` that patches the esp-idf framework (https://github.com/meshtastic/firmware/pull/11805).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for SD cards larger than 32 GB, including exFAT-formatted storage.
  * Map files can now be read reliably from large-capacity SD cards with offsets beyond 2 GB.

* **Bug Fixes**
  * Corrected SD card type and filesystem detection for larger cards.
  * Improved handling of file positions and read boundaries to prevent invalid map-file access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->