### PR TITLE
fix: prevent automatic programming mode on Bluetooth config update

### DIFF
--- a/source/graphics/TFT/TFTView_320x240.cpp
+++ b/source/graphics/TFT/TFTView_320x240.cpp
@@ -6558,7 +6558,7 @@ void TFTView_320x240::updateBluetoothConfig(const meshtastic_Config_BluetoothCon
         ownNode = id;
     }
 
-    if (state <= MeshtasticView::eBootScreenDone && state != MeshtasticView::eWaitingForReboot) {
+    if (state == MeshtasticView::eEnterProgrammingMode) {
         enterProgrammingMode();
     }
 }


### PR DESCRIPTION
## Problem

TFTView_320x240::updateBluetoothConfig() was calling
enterProgrammingMode() whenever the UI state was at or before
eBootScreenDone.

During normal boot, Bluetooth configuration updates can arrive while
the UI is still in a boot state. This caused the device to enter
Programming Mode without any user request.

## Fix

Only enter Programming Mode when the UI explicitly reaches
eEnterProgrammingMode.

This preserves the existing behavior of the long-press Bluetooth logo
while preventing automatic entry during normal boot.

## Change

Changed:

if (state <= MeshtasticView::eBootScreenDone &&
    state != MeshtasticView::eWaitingForReboot)

to:

if (state == MeshtasticView::eEnterProgrammingMode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Bluetooth configuration behavior so programming mode is entered only when explicitly requested.
  - Prevented boot and startup states from unintentionally switching the device into programming mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->